### PR TITLE
Dossiers do not open in WebGL

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 8900000, guid: ceb1e640e6a4fb7448e1c3d4c464d117, type: 3}
   m_Sun: {fileID: 1461716753}
-  m_IndirectSpecularColor: {r: 0.6356922, g: 0.7094109, b: 0.9096943, a: 1}
+  m_IndirectSpecularColor: {r: 0.63477623, g: 0.7107723, b: 0.9100152, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1718,12 +1718,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   configuration: {fileID: 11400000, guid: ef4fdd9a7713bc0458843a4884b6e1c5, type: 2}
   dossier: {fileID: 11400000, guid: 84a7c9f73f20c8c4ba60ce64ca5ef6d7, type: 2}
---- !u!1 &464166067 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2648030356980255278, guid: 3b1d8c004c65ae5488f8e271d65d05a6,
-    type: 3}
-  m_PrefabInstance: {fileID: 848014444}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &460259861 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6637341396108375670, guid: 212a3e5712f4eb94290526f16cf400ec,
@@ -1736,6 +1730,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 009dfb7b117049a1a3f2a2e9cb4e6db8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &464166067 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2648030356980255278, guid: 3b1d8c004c65ae5488f8e271d65d05a6,
+    type: 3}
+  m_PrefabInstance: {fileID: 848014444}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &479078705
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2333,7 +2333,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d950103801afa4458a2dda9c19a65f90, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  importManager: {fileID: 0}
 --- !u!1 &869426923
 GameObject:
   m_ObjectHideFlags: 0
@@ -3642,37 +3641,22 @@ PrefabInstance:
     - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.2688033
+      value: 0.67602897
       objectReference: {fileID: 0}
     - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.12099941
+      value: 0.10268737
       objectReference: {fileID: 0}
     - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.871354
+      value: 0.7214099
       objectReference: {fileID: 0}
     - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.39223227
-      objectReference: {fileID: 0}
-    - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.049645815
-      objectReference: {fileID: 0}
-    - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.011513068
-      objectReference: {fileID: 0}
-    - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.22561546
+      value: -0.10958064
       objectReference: {fileID: 0}
     - target: {fileID: 7539193515803747149, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
@@ -9085,8 +9069,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 4484998994330860989}
   m_HandleRect: {fileID: 4484998994330860990}
   m_Direction: 0
-  m_Value: 1
-  m_Size: 1
+  m_Value: 0
+  m_Size: 0.99999994
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/Assets/link.xml
+++ b/Assets/link.xml
@@ -1,0 +1,4 @@
+<linker>
+	<assembly fullname="GeoJSON.NET" preserve="all"></assembly>
+	<assembly fullname="eu.netherlands3d.json.Runtime" preserve="all"></assembly>
+</linker>

--- a/Assets/link.xml.meta
+++ b/Assets/link.xml.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5aea40d35adf432d9ccf36a9b30dfad7
+timeCreated: 1692284836

--- a/Packages/eu.netherlands3d.indicators/README.md
+++ b/Packages/eu.netherlands3d.indicators/README.md
@@ -17,6 +17,22 @@ or, you have to add `https://package.openupm.com` as a scoped registry with, at 
 - `eu.netherlands3d` and
 - `com.virgis.geojson.net`
 
+### WebGL
+
+When you want to use this package in a build intended for WebGL, do not forgot to add the following to `Assets/link.xml`
+in your project. This package relies on (de)serialisation using JSON.net and when Code Stripping is enabled, the linker
+will otherwise remove all JsonConverters and elements involved in the (de)serialisation of the code.
+
+```xml
+<linker>
+    <!-- Anything that is already in your link.xml -->
+	<assembly fullname="GeoJSON.NET" preserve="all"></assembly>
+	<assembly fullname="eu.netherlands3d.json.Runtime" preserve="all"></assembly>
+</linker>
+```
+
+If you do not have a `link.xml` file in the root of your `Assets` folder, you can create one with the contents above.
+
 ## Usage
 
 To make use of this package, you can follow these steps:

--- a/Packages/eu.netherlands3d.indicators/Runtime/Scripts/Dossiers/Indicators/Scores.cs
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Scripts/Dossiers/Indicators/Scores.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Netherlands3D.Json.JsonConverters;
 using Newtonsoft.Json;
 
@@ -7,6 +8,8 @@ namespace Netherlands3D.Indicators.Dossiers.Indicators
     [Serializable]
     public struct Scores
     {
+        public Dictionary<string, float> Values;
+
         [JsonConverter(typeof(UriConverter))]
         public Uri graph;
     }


### PR DESCRIPTION
To load the (Geo)JSON files we make use of JSON.net and its converters; but the code stripping of Unity removes all the JsonConverters and the dynamically instantiated classes from GeoJSON.net.

To counter this issue, I have added GeoJSON.net and the whole JSON-Extra's assembly to the `link.xml` instructions, this will prevent unity from stripping these files.

In addition, I have also added the new Indicator values array that can be used in presenting the indicators in the sidebar