### PR TITLE
Feature/select and render map layer

### DIFF
--- a/Assets/Prefabs/Indicators/MapLayerList.prefab
+++ b/Assets/Prefabs/Indicators/MapLayerList.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 2796954425654255465}
   - component: {fileID: 4578726788748017229}
   - component: {fileID: 7403344188885707571}
+  - component: {fileID: 6889337470636244178}
   m_Layer: 5
   m_Name: MapLayerList
   m_TagString: Untagged
@@ -87,6 +88,31 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_AllowSwitchOff: 1
+--- !u!114 &6889337470636244178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9065634154560002152}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d6f3283f5616bb4794538c755eb27cf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dossier: {fileID: 11400000, guid: 84a7c9f73f20c8c4ba60ce64ca5ef6d7, type: 2}
+  mapLayerList: {fileID: 7403344188885707571}
+  mapLayerListItemPrefab: {fileID: 7075544064532675156, guid: 2a92fda52a971904da62d9dc1b1585cb,
+    type: 3}
+  onSelectedMapOverlay:
+    m_PersistentCalls:
+      m_Calls: []
+  onLoadMapOverlayFrame:
+    m_PersistentCalls:
+      m_Calls: []
+  onDeselectedMapOverlay:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1001 &8135567614557188090
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -4983,22 +4983,22 @@ PrefabInstance:
     - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.6400227
+      value: 0.16535579
       objectReference: {fileID: 0}
     - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.06931478
+      value: 0.05907078
       objectReference: {fileID: 0}
     - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.76077455
+      value: 0.92708355
       objectReference: {fileID: 0}
     - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.08239227
+      value: -0.33118618
       objectReference: {fileID: 0}
     - target: {fileID: 7539193515803747149, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
@@ -12523,27 +12523,27 @@ PrefabInstance:
     - target: {fileID: 2528326767676104237, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2528326767676104237, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2528326767676104237, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 186
       objectReference: {fileID: 0}
     - target: {fileID: 2528326767676104237, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 2528326767676104237, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -161.70001
       objectReference: {fileID: 0}
     - target: {fileID: 2563035240863271198, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
@@ -12773,27 +12773,27 @@ PrefabInstance:
     - target: {fileID: 4726940777060982362, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4726940777060982362, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4726940777060982362, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 186
       objectReference: {fileID: 0}
     - target: {fileID: 4726940777060982362, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 4726940777060982362, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -23.1
       objectReference: {fileID: 0}
     - target: {fileID: 4791696509936873103, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
@@ -13168,27 +13168,27 @@ PrefabInstance:
     - target: {fileID: 5873604667062179328, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5873604667062179328, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5873604667062179328, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 186
       objectReference: {fileID: 0}
     - target: {fileID: 5873604667062179328, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 5873604667062179328, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -207.90001
       objectReference: {fileID: 0}
     - target: {fileID: 6029444848750721631, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
@@ -13293,52 +13293,52 @@ PrefabInstance:
     - target: {fileID: 7236596875970995787, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7236596875970995787, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7236596875970995787, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 186
       objectReference: {fileID: 0}
     - target: {fileID: 7236596875970995787, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 7236596875970995787, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -115.5
       objectReference: {fileID: 0}
     - target: {fileID: 7604421221410862962, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7604421221410862962, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7604421221410862962, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 186
       objectReference: {fileID: 0}
     - target: {fileID: 7604421221410862962, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 7604421221410862962, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -69.3
       objectReference: {fileID: 0}
     - target: {fileID: 8139773757600881731, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
@@ -13590,7 +13590,11 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1164069605219792946, guid: 212a3e5712f4eb94290526f16cf400ec,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6320741605732776937}
   m_SourcePrefab: {fileID: 100100000, guid: 212a3e5712f4eb94290526f16cf400ec, type: 3}
 --- !u!114 &6320741605732776933 stripped
 MonoBehaviour:
@@ -13602,6 +13606,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0fe145b4d6f54a5cbed4384921dfff8f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6320741605732776937
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1799500939}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ffd3f0c60922f1b4a9ed734b4a78d8e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &6398691407728572993
@@ -14216,7 +14232,7 @@ PrefabInstance:
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}
       propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}
@@ -14226,11 +14242,16 @@ PrefabInstance:
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}
       propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}
       propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
       value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
@@ -14240,9 +14261,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
       propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1799500939}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 460259861}
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}
       propertyPath: onLoadMapOverlayFrame.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -14255,7 +14286,17 @@ PrefabInstance:
       objectReference: {fileID: 1799500939}
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 460259861}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
       propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
@@ -14270,7 +14311,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: set_IsTransparent
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
       propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
@@ -14285,8 +14336,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: set_IsTransparent
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
       propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
       value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: Netherlands3D.Indicators.DossierVisualiser, eu.netherlands3d.indicators.Runtime
       objectReference: {fileID: 0}
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}
@@ -14300,12 +14361,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: Netherlands3D.Indicators.DossierVisualiser, eu.netherlands3d.indicators.Runtime
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
       propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_BoolArgument
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_BoolArgument
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
       propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
@@ -14316,6 +14392,11 @@ PrefabInstance:
     - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}
       propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 1523394267705780950, guid: c18057bd7c4172b4c8b2447dbf8456ca,
@@ -14662,6 +14743,176 @@ PrefabInstance:
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onLoadMapOverlayFrame.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1799500939}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 460259861}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onLoadMapOverlayFrame.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 6320741605732776933}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1799500939}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 460259861}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onLoadMapOverlayFrame.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: set_IsTransparent
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onLoadMapOverlayFrame.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Load
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: set_IsTransparent
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: Netherlands3D.Indicators.DossierVisualiser, eu.netherlands3d.indicators.Runtime
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onLoadMapOverlayFrame.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: Netherlands3D.Indicators.RemoteTextureLoader, eu.netherlands3d.indicators.Runtime
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: Netherlands3D.Indicators.DossierVisualiser, eu.netherlands3d.indicators.Runtime
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_BoolArgument
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_BoolArgument
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onLoadMapOverlayFrame.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 7167566248913596962, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 7394774688067365712, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -1950,39 +1950,31 @@ MonoBehaviour:
   onEvent: {fileID: 11400000, guid: 6880b3c628050c446b0706dde0c59508, type: 2}
   invertBoolean: 0
   disableAtLateStart: 1
---- !u!1 &460259855 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3248279717057453531, guid: 212a3e5712f4eb94290526f16cf400ec,
-    type: 3}
-  m_PrefabInstance: {fileID: 6320741605732776932}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &460259856 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6119329088547462491, guid: 212a3e5712f4eb94290526f16cf400ec,
     type: 3}
   m_PrefabInstance: {fileID: 6320741605732776932}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &460259860
+--- !u!114 &460259860 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 3207750023708683949, guid: 212a3e5712f4eb94290526f16cf400ec,
+    type: 3}
+  m_PrefabInstance: {fileID: 6320741605732776932}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 460259855}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f5401418c9304d51a77032699f1c97ad, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  configuration: {fileID: 11400000, guid: 9649637ffb6f9c24da61c215efe6adaa, type: 2}
-  dossier: {fileID: 11400000, guid: 84a7c9f73f20c8c4ba60ce64ca5ef6d7, type: 2}
 --- !u!114 &460259861 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6637341396108375670, guid: 212a3e5712f4eb94290526f16cf400ec,
     type: 3}
   m_PrefabInstance: {fileID: 6320741605732776932}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 460259855}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 009dfb7b117049a1a3f2a2e9cb4e6db8, type: 3}
@@ -4991,22 +4983,22 @@ PrefabInstance:
     - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.15523718
+      value: 0.6400227
       objectReference: {fileID: 0}
     - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.0568082
+      value: 0.06931478
       objectReference: {fileID: 0}
     - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.9261757
+      value: 0.76077455
       objectReference: {fileID: 0}
     - target: {fileID: 7539193515803747148, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.33892894
+      value: -0.08239227
       objectReference: {fileID: 0}
     - target: {fileID: 7539193515803747149, guid: 4ba44a31ba5f45f42b49235f06111c10,
         type: 3}
@@ -8436,6 +8428,12 @@ MonoBehaviour:
   onEvent: {fileID: 11400000, guid: 7d5149ba18d9f674e86a0f0ba4ec80ee, type: 2}
   invertBoolean: 0
   disableAtLateStart: 1
+--- !u!1 &1799500939 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1164069605219792946, guid: 212a3e5712f4eb94290526f16cf400ec,
+    type: 3}
+  m_PrefabInstance: {fileID: 6320741605732776932}
+  m_PrefabAsset: {fileID: 0}
 --- !u!224 &1814402481 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5481661298731546440, guid: 4f23765e56f13144b9405d18346ce321,
@@ -13511,31 +13509,6 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
         type: 3}
-      propertyPath: onOpen.m_PersistentCalls.m_Calls.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onClose.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onOpen.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onOpen.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onClose.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
       propertyPath: onOpen.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1732596340}
@@ -13549,76 +13522,6 @@ PrefabInstance:
       propertyPath: onClose.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1732596341}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onOpen.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onOpen.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onClose.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onOpen.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: SetActive
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onOpen.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: set_interactable
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onClose.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: set_interactable
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onOpen.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: UnityEngine.GameObject, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onOpen.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: UnityEngine.UI.Selectable, UnityEngine.UI
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onClose.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: UnityEngine.UI.Selectable, UnityEngine.UI
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onOpen.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_BoolArgument
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onOpen.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_BoolArgument
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onOpen.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onOpen.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 589428993377803893, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: onClose.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
     - target: {fileID: 3248279717057453531, guid: 212a3e5712f4eb94290526f16cf400ec,
         type: 3}
       propertyPath: m_Name
@@ -13628,6 +13531,41 @@ PrefabInstance:
         type: 3}
       propertyPath: m_RootOrder
       value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6119329088547462491, guid: 212a3e5712f4eb94290526f16cf400ec,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6119329088547462491, guid: 212a3e5712f4eb94290526f16cf400ec,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6119329088547462491, guid: 212a3e5712f4eb94290526f16cf400ec,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6119329088547462491, guid: 212a3e5712f4eb94290526f16cf400ec,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6119329088547462491, guid: 212a3e5712f4eb94290526f16cf400ec,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6119329088547462491, guid: 212a3e5712f4eb94290526f16cf400ec,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6119329088547462491, guid: 212a3e5712f4eb94290526f16cf400ec,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6119329088547462491, guid: 212a3e5712f4eb94290526f16cf400ec,
         type: 3}
@@ -13649,20 +13587,23 @@ PrefabInstance:
       propertyPath: targetGameObject
       value: 
       objectReference: {fileID: 767208734}
-    - target: {fileID: 7562979231812192285, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      propertyPath: ZoomToShowWholeExtend
-      value: 1
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3248279717057453531, guid: 212a3e5712f4eb94290526f16cf400ec,
-        type: 3}
-      insertIndex: 1
-      addedObject: {fileID: 460259860}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 212a3e5712f4eb94290526f16cf400ec, type: 3}
+--- !u!114 &6320741605732776933 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1390869371171006683, guid: 212a3e5712f4eb94290526f16cf400ec,
+    type: 3}
+  m_PrefabInstance: {fileID: 6320741605732776932}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1799500939}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0fe145b4d6f54a5cbed4384921dfff8f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &6398691407728572993
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14272,6 +14213,111 @@ PrefabInstance:
       propertyPath: dossierVisualiser
       value: 
       objectReference: {fileID: 460259861}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onLoadMapOverlayFrame.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1799500939}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onLoadMapOverlayFrame.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 6320741605732776933}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1799500939}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onLoadMapOverlayFrame.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onLoadMapOverlayFrame.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Load
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onLoadMapOverlayFrame.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: Netherlands3D.Indicators.RemoteTextureLoader, eu.netherlands3d.indicators.Runtime
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_BoolArgument
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onSelectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onLoadMapOverlayFrame.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 753543407501609544, guid: c18057bd7c4172b4c8b2447dbf8456ca,
+        type: 3}
+      propertyPath: onDeselectedMapOverlay.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 1523394267705780950, guid: c18057bd7c4172b4c8b2447dbf8456ca,
         type: 3}
       propertyPath: m_AnchorMax.y

--- a/Packages/eu.netherlands3d.indicators/Runtime/Prefabs/Indicators.prefab
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Prefabs/Indicators.prefab
@@ -9,8 +9,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6119329088547462491}
+  - component: {fileID: 3207750023708683949}
   - component: {fileID: 589428993377803893}
   - component: {fileID: 7562979231812192285}
+  - component: {fileID: 6772795621031016247}
   - component: {fileID: 6637341396108375670}
   m_Layer: 0
   m_Name: Indicators
@@ -30,10 +32,25 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 5958090720409276893}
   m_Father: {fileID: 0}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3207750023708683949
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3248279717057453531}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5401418c9304d51a77032699f1c97ad, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  configuration: {fileID: 11400000, guid: 9649637ffb6f9c24da61c215efe6adaa, type: 2}
+  dossier: {fileID: 11400000, guid: 84a7c9f73f20c8c4ba60ce64ca5ef6d7, type: 2}
 --- !u!114 &589428993377803893
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -49,7 +66,31 @@ MonoBehaviour:
   Dossier: {fileID: 11400000, guid: 84a7c9f73f20c8c4ba60ce64ca5ef6d7, type: 2}
   onOpen:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: UnityEngine.UI.Selectable, UnityEngine.UI
+        m_MethodName: set_interactable
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
   onSelectedVariant:
     m_PersistentCalls:
       m_Calls: []
@@ -58,7 +99,19 @@ MonoBehaviour:
       m_Calls: []
   onClose:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: UnityEngine.UI.Selectable, UnityEngine.UI
+        m_MethodName: set_interactable
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   onLoadedProjectArea:
     m_PersistentCalls:
       m_Calls:
@@ -88,6 +141,19 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 6772795621031016247}
+        m_TargetAssemblyTypeName: Netherlands.GeoJSON.MoveToCenterOfFeatureCollection,
+          eu.netherlands3d.geojson.Runtime
+        m_MethodName: CenterOn
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &7562979231812192285
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -104,6 +170,25 @@ MonoBehaviour:
   fitToBounds: 1
   fittingDistanceModifier: 0.75
   movingDuration: 1
+  onPositionChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &6772795621031016247
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3248279717057453531}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6499ae627235474abee37e9eaa7a93b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  targetGameObject: {fileID: 1164069605219792946}
+  fitToBounds: 1
+  fittingDistanceModifier: 0.75
+  movingDuration: 0
   onPositionChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -134,3 +219,130 @@ MonoBehaviour:
   onSelectedArea:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1001 &2726562957860431216
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6119329088547462491}
+    m_Modifications:
+    - target: {fileID: 3886933802206240066, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: m_Name
+      value: OverlayProjector
+      objectReference: {fileID: 0}
+    - target: {fileID: 3935001219056799147, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: onTextureLoaded.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3935001219056799147, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: onTextureLoaded.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 6430938360508834454}
+    - target: {fileID: 3935001219056799147, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: onTextureLoaded.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3935001219056799147, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: onTextureLoaded.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetTexture
+      objectReference: {fileID: 0}
+    - target: {fileID: 3935001219056799147, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: onTextureLoaded.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: Netherlands3D.Rendering.TextureDecalProjector, Netherlands3D.Rendering.Runtime
+      objectReference: {fileID: 0}
+    - target: {fileID: 3935001219056799147, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: onTextureLoaded.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609142377514906797, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609142377514906797, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609142377514906797, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609142377514906797, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609142377514906797, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710784
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609142377514906797, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.70710576
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609142377514906797, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609142377514906797, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609142377514906797, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609142377514906797, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8609142377514906797, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 97d41d85bcf14ef9978a4265d4d52cd8, type: 3}
+--- !u!1 &1164069605219792946 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3886933802206240066, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 2726562957860431216}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &5958090720409276893 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8609142377514906797, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 2726562957860431216}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6430938360508834454 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9001001091731392486, guid: 97d41d85bcf14ef9978a4265d4d52cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 2726562957860431216}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1164069605219792946}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 035e888fc4a96fb40b69129b857c880a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Packages/eu.netherlands3d.indicators/Runtime/Prefabs/OverlayProjector.prefab
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Prefabs/OverlayProjector.prefab
@@ -1,0 +1,112 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &4800136587739796238
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2182191336397338675, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 750
+      objectReference: {fileID: 0}
+    - target: {fileID: 2182191336397338675, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883320769536567203, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883320769536567203, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883320769536567203, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883320769536567203, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883320769536567203, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710784
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883320769536567203, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.70710576
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883320769536567203, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883320769536567203, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883320769536567203, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883320769536567203, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3883320769536567203, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8605441521365290572, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      propertyPath: m_Name
+      value: OverlayProjector
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8605441521365290572, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3935001219056799147}
+  m_SourcePrefab: {fileID: 100100000, guid: d62ffe26c4958754e9ee3be0a03b28f6, type: 3}
+--- !u!1 &3886933802206240066 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8605441521365290572, guid: d62ffe26c4958754e9ee3be0a03b28f6,
+    type: 3}
+  m_PrefabInstance: {fileID: 4800136587739796238}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3935001219056799147
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3886933802206240066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0fe145b4d6f54a5cbed4384921dfff8f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  url: 
+  fallbackTexture: {fileID: 2800000, guid: 6a71a97200afaf74fa8e7e7926ef031e, type: 3}
+  onTextureLoaded:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Packages/eu.netherlands3d.indicators/Runtime/Prefabs/OverlayProjector.prefab.meta
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Prefabs/OverlayProjector.prefab.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 97d41d85bcf14ef9978a4265d4d52cd8
+timeCreated: 1694438752

--- a/Packages/eu.netherlands3d.indicators/Runtime/Scripts/RemoteTextureLoader.cs
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Scripts/RemoteTextureLoader.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.Networking;
+
+namespace Netherlands3D.Indicators
+{
+    public class RemoteTextureLoader : MonoBehaviour
+    {
+        public Texture2D fallbackTexture;
+
+        public UnityEvent<Texture2D> onTextureLoaded = new();
+
+        public void Load(Uri uri)
+        {
+            // We always load the fallback immediately, and then start downloading
+            if (fallbackTexture) onTextureLoaded.Invoke(fallbackTexture);
+            
+            StartCoroutine(LoadRemoteTexture(uri.ToString()));
+        }
+
+        private IEnumerator LoadRemoteTexture(string textureUrl)
+        {
+            var webRequest = UnityWebRequestTexture.GetTexture(textureUrl, false);
+            
+            yield return webRequest.SendWebRequest();
+
+            if (webRequest.result != UnityWebRequest.Result.Success)
+            {
+                Debug.LogError($"Could not download {textureUrl}");
+                yield break;
+            }
+
+            Texture2D myTexture = ((DownloadHandlerTexture)webRequest.downloadHandler).texture;
+            myTexture.Compress(false);
+            myTexture.wrapMode = TextureWrapMode.Clamp;
+
+            onTextureLoaded.Invoke(myTexture);
+        }
+    }
+}

--- a/Packages/eu.netherlands3d.indicators/Runtime/Scripts/RemoteTextureLoader.cs.meta
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Scripts/RemoteTextureLoader.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0fe145b4d6f54a5cbed4384921dfff8f
+timeCreated: 1687423766

--- a/Packages/eu.netherlands3d.indicators/Runtime/Scripts/UI/MapList.cs
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Scripts/UI/MapList.cs
@@ -1,0 +1,78 @@
+using TMPro;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+using System.Linq;
+using Netherlands3D.Indicators.Dossiers;
+using UnityEngine.Events;
+using UnityEngine.Serialization;
+using UnityEngine.UI;
+
+namespace Netherlands3D.Indicators.UI
+{
+    public class MapList : MonoBehaviour
+    {
+        [SerializeField] private DossierSO dossier;
+        [SerializeField] private ToggleGroup mapLayerList;
+        [SerializeField] private Toggle mapLayerListItemPrefab;
+
+        public UnityEvent<DataLayer> onSelectedMapOverlay = new();
+        public UnityEvent<Uri> onLoadMapOverlayFrame = new();
+        public UnityEvent onDeselectedMapOverlay = new();
+
+        private void OnEnable()
+        {
+            dossier.onSelectedVariant.AddListener(OnSelectedVariant);
+            PopulateMapLayerList(dossier.ActiveVariant);
+        }
+
+        private void OnDisable()
+        {
+            // Make sure the overlay is cleared when this item is no longer active
+            onDeselectedMapOverlay.Invoke();
+            dossier.onSelectedVariant.RemoveListener(OnSelectedVariant);
+        }
+
+        private void OnSelectedVariant(Variant? variant)
+        {
+            PopulateMapLayerList(variant);
+        }
+
+        private void PopulateMapLayerList(Variant? variant)
+        {
+            if (!mapLayerList) return;
+
+            mapLayerList.transform.ClearAllChildren();
+            onDeselectedMapOverlay.Invoke();
+
+            if (variant.HasValue == false) return;
+
+            foreach (var dataLayer in variant.Value.maps)
+            {
+                var listItem = Instantiate(mapLayerListItemPrefab, mapLayerList.transform);
+                listItem.GetComponentInChildren<TMP_Text>().text = dataLayer.Value.name;
+                listItem.group = mapLayerList;
+
+                listItem.onValueChanged.AddListener((toggledOn) => OnToggledMapListItem(dataLayer.Value, toggledOn));
+            }
+        }
+
+        private void OnToggledMapListItem(DataLayer dataLayer, bool toggledOn)
+        {
+            if (!toggledOn)
+            {
+                onDeselectedMapOverlay.Invoke();
+                return;
+            }
+
+            onSelectedMapOverlay.Invoke(dataLayer);
+
+            if (dataLayer.frames.Count == 0) return;
+
+            // since we do not support multiple frames at the moment, we cheat and always load the first
+            var firstFrame = dataLayer.frames.First();
+            onLoadMapOverlayFrame.Invoke(firstFrame.map);
+        }
+    }
+}

--- a/Packages/eu.netherlands3d.indicators/Runtime/Scripts/UI/MapList.cs.meta
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Scripts/UI/MapList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d6f3283f5616bb4794538c755eb27cf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/eu.netherlands3d.indicators/Runtime/Scripts/UI/Sidebar.cs
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Scripts/UI/Sidebar.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Linq;
-using Netherlands3D.Indicators.Dossiers;
 using TMPro;
 using UnityEngine;
-using UnityEngine.Events;
-using UnityEngine.Serialization;
-using UnityEngine.UI;
 
 namespace Netherlands3D.Indicators.UI
 {
@@ -15,18 +9,13 @@ namespace Netherlands3D.Indicators.UI
         [SerializeField] private DossierVisualiser dossierVisualiser;
         [SerializeField] private TMP_Text nameField;
         [SerializeField] private TMP_Text projectAreaNameField;
-        [SerializeField] private ToggleGroup mapLayerList;
-        [SerializeField] private Toggle mapLayerListItemPrefab;
 
-        public UnityEvent<DataLayer> onSelectedMapOverlay = new();
-        [FormerlySerializedAs("onLoadMapOverlay")] public UnityEvent<Uri> onLoadMapOverlayFrame = new();
-        public UnityEvent onDeselectedMapOverlay = new();
-        
         private void OnEnable()
         {
+            dossierVisualiser.onSelectedArea.AddListener(OnSelectedArea);
+
             if (nameField) nameField.text = dossier.Data.HasValue ? dossier.Data.Value.name : "";
             if (projectAreaNameField) projectAreaNameField.text = "Please select a project area.";
-            dossierVisualiser.onSelectedArea.AddListener(OnSelectedArea);
         }
 
         private void OnDisable()
@@ -37,42 +26,6 @@ namespace Netherlands3D.Indicators.UI
         private void OnSelectedArea(ProjectAreaVisualisation visualisation)
         {
             if (projectAreaNameField) projectAreaNameField.text = visualisation.ProjectArea.name;
-            PopulateMapLayerList();
-        }
-
-        private void PopulateMapLayerList()
-        {
-            if (!mapLayerList) return;
-
-            mapLayerList.transform.ClearAllChildren();
-            onDeselectedMapOverlay.Invoke();
-
-            var activeVariant = dossier.ActiveVariant;
-            if (activeVariant.HasValue == false) return;
-
-            foreach (var dataLayer in activeVariant.Value.maps)
-            {
-                var listItem = Instantiate(mapLayerListItemPrefab, mapLayerList.transform);
-                listItem.GetComponentInChildren<TMP_Text>().text = dataLayer.Value.name;
-                listItem.group = mapLayerList;
-                listItem.onValueChanged.AddListener(toggledOn =>
-                {
-                    if (toggledOn)
-                    {
-                        onSelectedMapOverlay.Invoke(dataLayer.Value);
-
-                        if (dataLayer.Value.frames.Count == 0) return;
-
-                        // since we do not support multiple frames at the moment, we cheat and always load the first
-                        var firstFrame = dataLayer.Value.frames.First();
-                        onLoadMapOverlayFrame.Invoke(firstFrame.map);
-
-                        return;
-                    }
-
-                    onDeselectedMapOverlay.Invoke();
-                });
-            }
         }
     }
 }


### PR DESCRIPTION
In this change, when a map overlay is selected it is shown on top of the project area. To prevent issues with colors interfering with one another, the fill of the project area is temporarily removed. Part of the complexity of the issue was also that the overlay should be removed again when deselecting the map overlay and when you close the indicator dossier feature.