### PR TITLE
use proper highlight vertex color

### DIFF
--- a/Assets/Materials/Layers/Twin_Gebouwen.mat
+++ b/Assets/Materials/Layers/Twin_Gebouwen.mat
@@ -13,6 +13,7 @@ Material:
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
+  - _SUBOBJECT_FILTERING
   - _TEXTURINGMODE_SKIP_TEXTURE
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -54,7 +55,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTexture:
-        m_Texture: {fileID: 2800000, guid: cf9c0bfd082c78643af533d8c341fd49, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MaskMap:
@@ -114,7 +115,7 @@ Material:
     - _QueueOffset: 0
     - _ReceiveShadows: 1
     - _SPHERICAL_MASKING: 0
-    - _SUBOBJECT_FILTERING: 0
+    - _SUBOBJECT_FILTERING: 1
     - _Shininess: 0
     - _Smoothness: 0.5
     - _SmoothnessSource: 0

--- a/Assets/Prefabs/TileHandler.prefab
+++ b/Assets/Prefabs/TileHandler.prefab
@@ -467,7 +467,7 @@ MonoBehaviour:
   applyHideOnReload: 0
   applyOnExistingTiles: 1
   maxSelectDistance: 8000
-  selectionVertexColor: {r: 0.99215686, g: 1, b: 0, a: 1}
+  selectionVertexColor: {r: 1, g: 0, b: 0, a: 0}
   clickedOnObject: {fileID: 11400000, guid: 4146b375f6ddaf446bf55ba4dbd171ad, type: 2}
   selectedIdsOnClick: {fileID: 11400000, guid: 9fccc0f026026d04bbc9a12ffd985622, type: 2}
   clickedOnPosition: {fileID: 11400000, guid: 1a3fcaa9dcfd1924385e66fd0012b8ba, type: 2}


### PR DESCRIPTION
New shader uses a specific color ID for subobject highlighting.
Buildings layer 'SelectSubObjects' script now uses Red with Alpha 0 as highlight vertex color.

The Buildings SubObjects filtering feature was enabled in order to use this new feature.

<img width="436" alt="image" src="https://github.com/Netherlands3D/twin/assets/11850024/863aafe5-3343-4e71-9b07-2363b906d899">
