### PR TITLE
added keyword to main shader to allow clamping of spikes in terrain

### DIFF
--- a/Assets/Materials/Layers/Twin_Begroeid.mat
+++ b/Assets/Materials/Layers/Twin_Begroeid.mat
@@ -127,16 +127,20 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _IncludeInGlobalMask: 1
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SPIKE_CLAMPING: 0
+    - _SPIKE_FILTERING: 0
     - _SUBOBJECT_FILTERING: 0
     - _Smoothness: 0.02
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SphericalMask: 0
+    - _SpikeClampHeight: 320
     - _SrcBlend: 1
     - _Surface: 0
     - _TEXTURINGMODE: 2

--- a/Assets/Materials/Layers/Twin_Bruggen.mat
+++ b/Assets/Materials/Layers/Twin_Bruggen.mat
@@ -110,15 +110,19 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _IncludeInGlobalMask: 1
     - _Metallic: 0.08
     - _OcclusionStrength: 1
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SPIKE_CLAMPING: 0
+    - _SPIKE_FILTERING: 0
     - _SUBOBJECT_FILTERING: 0
     - _Smoothness: 0.13
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
+    - _SpikeClampHeight: 320
     - _SrcBlend: 1
     - _Surface: 0
     - _TEXTURINGMODE: 1

--- a/Assets/Materials/Layers/Twin_Constructies.mat
+++ b/Assets/Materials/Layers/Twin_Constructies.mat
@@ -123,15 +123,19 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _IncludeInGlobalMask: 1
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SPIKE_CLAMPING: 0
+    - _SPIKE_FILTERING: 0
     - _SUBOBJECT_FILTERING: 0
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
+    - _SpikeClampHeight: 320
     - _SrcBlend: 1
     - _Surface: 0
     - _TEXTURINGMODE: 1

--- a/Assets/Materials/Layers/Twin_Erven.mat
+++ b/Assets/Materials/Layers/Twin_Erven.mat
@@ -110,15 +110,19 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _IncludeInGlobalMask: 1
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SPIKE_CLAMPING: 0
+    - _SPIKE_FILTERING: 0
     - _SUBOBJECT_FILTERING: 0
     - _Smoothness: 0.03
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
+    - _SpikeClampHeight: 320
     - _SrcBlend: 1
     - _Surface: 0
     - _TEXTURINGMODE: 1

--- a/Assets/Materials/Layers/Twin_Fietspaden.mat
+++ b/Assets/Materials/Layers/Twin_Fietspaden.mat
@@ -123,15 +123,19 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _IncludeInGlobalMask: 1
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SPIKE_CLAMPING: 0
+    - _SPIKE_FILTERING: 0
     - _SUBOBJECT_FILTERING: 0
     - _Smoothness: 0.38
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
+    - _SpikeClampHeight: 320
     - _SrcBlend: 1
     - _Surface: 0
     - _TEXTURINGMODE: 1

--- a/Assets/Materials/Layers/Twin_Onbegroeid.mat
+++ b/Assets/Materials/Layers/Twin_Onbegroeid.mat
@@ -123,15 +123,19 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _IncludeInGlobalMask: 1
     - _Metallic: 0.08
     - _OcclusionStrength: 1
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SPIKE_CLAMPING: 0
+    - _SPIKE_FILTERING: 0
     - _SUBOBJECT_FILTERING: 0
     - _Smoothness: 0.13
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
+    - _SpikeClampHeight: 320
     - _SrcBlend: 1
     - _Surface: 0
     - _TEXTURINGMODE: 1

--- a/Assets/Materials/Layers/Twin_Onverhard oppervlak.mat
+++ b/Assets/Materials/Layers/Twin_Onverhard oppervlak.mat
@@ -123,15 +123,18 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _IncludeInGlobalMask: 1
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SPIKE_CLAMPING: 0
     - _SUBOBJECT_FILTERING: 0
     - _Smoothness: 0.14
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
+    - _SpikeClampHeight: 320
     - _SrcBlend: 1
     - _Surface: 0
     - _TEXTURINGMODE: 1

--- a/Assets/Materials/Layers/Twin_Parkeervakken.mat
+++ b/Assets/Materials/Layers/Twin_Parkeervakken.mat
@@ -14,7 +14,8 @@ Material:
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - _TEXTURINGMODE_USE_WORLD_SPACE_UV
-  m_InvalidKeywords: []
+  m_InvalidKeywords:
+  - _SPIKE_FILTERING
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -110,15 +111,19 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _IncludeInGlobalMask: 1
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SPIKE_CLAMPING: 0
+    - _SPIKE_FILTERING: 1
     - _SUBOBJECT_FILTERING: 0
     - _Smoothness: 0.22
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
+    - _SpikeClampHeight: 320
     - _SrcBlend: 1
     - _Surface: 0
     - _TEXTURINGMODE: 1

--- a/Assets/Materials/Layers/Twin_Parkeervakken.mat
+++ b/Assets/Materials/Layers/Twin_Parkeervakken.mat
@@ -118,7 +118,7 @@ Material:
     - _QueueOffset: 0
     - _ReceiveShadows: 1
     - _SPIKE_CLAMPING: 0
-    - _SPIKE_FILTERING: 1
+    - _SPIKE_FILTERING: 0
     - _SUBOBJECT_FILTERING: 0
     - _Smoothness: 0.22
     - _SmoothnessTextureChannel: 0

--- a/Assets/Materials/Layers/Twin_Spoorbanen.mat
+++ b/Assets/Materials/Layers/Twin_Spoorbanen.mat
@@ -123,15 +123,19 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _IncludeInGlobalMask: 1
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SPIKE_CLAMPING: 0
+    - _SPIKE_FILTERING: 0
     - _SUBOBJECT_FILTERING: 0
     - _Smoothness: 0.19
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
+    - _SpikeClampHeight: 320
     - _SrcBlend: 1
     - _Surface: 0
     - _TEXTURINGMODE: 1

--- a/Assets/Materials/Layers/Twin_Verhard oppervlak.mat
+++ b/Assets/Materials/Layers/Twin_Verhard oppervlak.mat
@@ -123,15 +123,18 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _IncludeInGlobalMask: 1
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SPIKE_CLAMPING: 0
     - _SUBOBJECT_FILTERING: 0
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
+    - _SpikeClampHeight: 320
     - _SrcBlend: 1
     - _Surface: 0
     - _TEXTURINGMODE: 1

--- a/Assets/Materials/Layers/Twin_Voetpaden.mat
+++ b/Assets/Materials/Layers/Twin_Voetpaden.mat
@@ -123,16 +123,20 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _IncludeInGlobalMask: 1
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SPIKE_CLAMPING: 0
+    - _SPIKE_FILTERING: 0
     - _SUBOBJECTFILTERING: 1
     - _SUBOBJECT_FILTERING: 0
     - _Smoothness: 0.35
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
+    - _SpikeClampHeight: 320
     - _SrcBlend: 1
     - _Surface: 0
     - _TEXTURINGMODE: 1

--- a/Assets/Materials/Layers/Twin_Wegen.mat
+++ b/Assets/Materials/Layers/Twin_Wegen.mat
@@ -128,11 +128,14 @@ Material:
     - _Glossiness: 0
     - _GlossinessSource: 0
     - _GlossyReflections: 0
+    - _IncludeInGlobalMask: 1
     - _Metallic: 0.08
     - _OcclusionStrength: 1
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SPIKE_CLAMPING: 0
+    - _SPIKE_FILTERING: 0
     - _SUBOBJECTFILTERING: 0
     - _SUBOBJECT_FILTERING: 0
     - _Shininess: 0
@@ -141,6 +144,7 @@ Material:
     - _SmoothnessTextureChannel: 0
     - _SpecSource: 0
     - _SpecularHighlights: 1
+    - _SpikeClampHeight: 320
     - _SrcBlend: 1
     - _Surface: 0
     - _TEXTURINGMODE: 1

--- a/Assets/Materials/Layers/Twin_Woonerven.mat
+++ b/Assets/Materials/Layers/Twin_Woonerven.mat
@@ -110,15 +110,19 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
+    - _IncludeInGlobalMask: 1
     - _Metallic: 0
     - _OcclusionStrength: 1
     - _QueueControl: 0
     - _QueueOffset: 0
     - _ReceiveShadows: 1
+    - _SPIKE_CLAMPING: 0
+    - _SPIKE_FILTERING: 0
     - _SUBOBJECT_FILTERING: 0
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
+    - _SpikeClampHeight: 320
     - _SrcBlend: 1
     - _Surface: 0
     - _TEXTURINGMODE: 1

--- a/Assets/Shaders/Twin_MainLayers.shadergraph
+++ b/Assets/Shaders/Twin_MainLayers.shadergraph
@@ -44,6 +44,9 @@
         },
         {
             "m_Id": "8ada117110a04eecbc3c29a33dbaf2f8"
+        },
+        {
+            "m_Id": "4069feaa7d784755984e5ff0e5d617c7"
         }
     ],
     "m_Keywords": [
@@ -55,6 +58,9 @@
         },
         {
             "m_Id": "c302a7a66fe84616aa30ecca58cd91fe"
+        },
+        {
+            "m_Id": "f335930675b84fdeb512977b7f7ee921"
         }
     ],
     "m_Dropdowns": [],
@@ -225,6 +231,27 @@
         },
         {
             "m_Id": "6cc1dae2fe194edc9ca1409e1a3e9eab"
+        },
+        {
+            "m_Id": "13d7deaf430645888df5c5ca36ec6254"
+        },
+        {
+            "m_Id": "0ef6fa315b904fc4bf6773f3d01382ba"
+        },
+        {
+            "m_Id": "e6b5b911093740168b63f16720b31cad"
+        },
+        {
+            "m_Id": "0f9199666b0241a581ee2d163cd80917"
+        },
+        {
+            "m_Id": "e0c490ebde5a455d9a47b3718baca303"
+        },
+        {
+            "m_Id": "b11cb5e542ef4a1fa13215ef06d6f5d7"
+        },
+        {
+            "m_Id": "344c3b80368b4093bc2dc03f98b7d897"
         }
     ],
     "m_GroupDatas": [
@@ -239,6 +266,9 @@
         },
         {
             "m_Id": "7edafca82e2e41458cafaf9391535f23"
+        },
+        {
+            "m_Id": "6487c63405774d5ca4669ee91eef53de"
         }
     ],
     "m_StickyNoteDatas": [
@@ -296,6 +326,104 @@
                     "m_Id": "3e984393324b48f291f7faafad553d13"
                 },
                 "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "0ef6fa315b904fc4bf6773f3d01382ba"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "e6b5b911093740168b63f16720b31cad"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "0ef6fa315b904fc4bf6773f3d01382ba"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "0f9199666b0241a581ee2d163cd80917"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "0ef6fa315b904fc4bf6773f3d01382ba"
+                },
+                "m_SlotId": 3
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "e6b5b911093740168b63f16720b31cad"
+                },
+                "m_SlotId": 3
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "0f9199666b0241a581ee2d163cd80917"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "e0c490ebde5a455d9a47b3718baca303"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "13d7deaf430645888df5c5ca36ec6254"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "0ef6fa315b904fc4bf6773f3d01382ba"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "13d7deaf430645888df5c5ca36ec6254"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "b11cb5e542ef4a1fa13215ef06d6f5d7"
+                },
+                "m_SlotId": 2
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "13d7deaf430645888df5c5ca36ec6254"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "e0c490ebde5a455d9a47b3718baca303"
+                },
+                "m_SlotId": 2
             }
         },
         {
@@ -448,6 +576,20 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "3e599a3befc44de882faf7e452e4b771"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "344c3b80368b4093bc2dc03f98b7d897"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "0f9199666b0241a581ee2d163cd80917"
                 },
                 "m_SlotId": 1
             }
@@ -945,6 +1087,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "b11cb5e542ef4a1fa13215ef06d6f5d7"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "a617d3651f784e1596dfa5037221bdae"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "b3bc2fb01b67405cab9af37ce20dcd3c"
                 },
                 "m_SlotId": 2
@@ -1015,6 +1171,34 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "e0c490ebde5a455d9a47b3718baca303"
+                },
+                "m_SlotId": 3
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "b11cb5e542ef4a1fa13215ef06d6f5d7"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "e6b5b911093740168b63f16720b31cad"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "e0c490ebde5a455d9a47b3718baca303"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "fb0a79709da64438b9d7bae4fcf84fca"
                 },
                 "m_SlotId": 0
@@ -1029,8 +1213,8 @@
     ],
     "m_VertexContext": {
         "m_Position": {
-            "x": 29.9999942779541,
-            "y": -338.0
+            "x": 30.00004005432129,
+            "y": -292.666748046875
         },
         "m_Blocks": [
             {
@@ -1549,6 +1733,21 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "0e839db23e784b1795ee8781c6de138d",
+    "m_Id": 3,
+    "m_DisplayName": "B",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "0eb85233ff0448929a90986d07f4a7d5",
     "m_Id": 0,
     "m_DisplayName": "A",
@@ -1559,6 +1758,97 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SplitNode",
+    "m_ObjectId": "0ef6fa315b904fc4bf6773f3d01382ba",
+    "m_Group": {
+        "m_Id": "6487c63405774d5ca4669ee91eef53de"
+    },
+    "m_Name": "Split",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -97.99998474121094,
+            "y": -915.3334350585938,
+            "width": 120.66667175292969,
+            "height": 150.66668701171876
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "4e065ca7ab0648eda36107c5c9fab497"
+        },
+        {
+            "m_Id": "189b36f254934e72b2d79e5aeb161b1c"
+        },
+        {
+            "m_Id": "8f558c1929234c5387086f10f7d6d218"
+        },
+        {
+            "m_Id": "0e839db23e784b1795ee8781c6de138d"
+        },
+        {
+            "m_Id": "450d5e1489b8425cb84d9d6c88b8da51"
+        }
+    ],
+    "synonyms": [
+        "separate"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ComparisonNode",
+    "m_ObjectId": "0f9199666b0241a581ee2d163cd80917",
+    "m_Group": {
+        "m_Id": "6487c63405774d5ca4669ee91eef53de"
+    },
+    "m_Name": "Comparison",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 128.66671752929688,
+            "y": -990.6668090820313,
+            "width": 147.33328247070313,
+            "height": 138.666748046875
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "d03652eed02f4a7bacf65d09c9ed9c03"
+        },
+        {
+            "m_Id": "a8d7e37df107401393ca0d80c61a264a"
+        },
+        {
+            "m_Id": "b607ea44e2b54941a2bd109a5d1c70b2"
+        }
+    ],
+    "synonyms": [
+        "equal",
+        "greater than",
+        "less than"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_ComparisonType": 4
 }
 
 {
@@ -1600,6 +1890,43 @@
 }
 
 {
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.PositionNode",
+    "m_ObjectId": "13d7deaf430645888df5c5ca36ec6254",
+    "m_Group": {
+        "m_Id": "6487c63405774d5ca4669ee91eef53de"
+    },
+    "m_Name": "Position",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -340.0,
+            "y": -1218.666748046875,
+            "width": 209.33334350585938,
+            "height": 318.666748046875
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "fe4883d8c22848398ab8516c6856975e"
+        }
+    ],
+    "synonyms": [
+        "location"
+    ],
+    "m_Precision": 1,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 2,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Space": 0,
+    "m_PositionSource": 0
+}
+
+{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BooleanMaterialSlot",
     "m_ObjectId": "1478ea1ef1f74e3db7aaa19e16e4ae17",
@@ -1624,6 +1951,23 @@
     "m_ShaderOutputName": "Sampler",
     "m_StageCapability": 3,
     "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "1525cd9c95e74ec587191f20deb8abd7",
+    "m_Id": 3,
+    "m_DisplayName": "Z",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Z",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [
+        "Z"
+    ]
 }
 
 {
@@ -1711,6 +2055,21 @@
     "m_Property": {
         "m_Id": "eb8c7b44065947f7a3e6dd7b307c3f91"
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "189b36f254934e72b2d79e5aeb161b1c",
+    "m_Id": 1,
+    "m_DisplayName": "R",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "R",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -2300,6 +2659,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "344c3b80368b4093bc2dc03f98b7d897",
+    "m_Group": {
+        "m_Id": "6487c63405774d5ca4669ee91eef53de"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -150.0,
+            "y": -657.0,
+            "width": 172.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "48ce93bd43d94364ad850be6261147ca"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "4069feaa7d784755984e5ff0e5d617c7"
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "348d2ab08da84388a7178b01cc02db95",
     "m_Id": 0,
@@ -2793,6 +3188,20 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BooleanMaterialSlot",
+    "m_ObjectId": "3e6dfcbd03684897b23125526a7d19ab",
+    "m_Id": 0,
+    "m_DisplayName": "Predicate",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Predicate",
+    "m_StageCapability": 3,
+    "m_Value": false,
+    "m_DefaultValue": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.AndNode",
     "m_ObjectId": "3e984393324b48f291f7faafad553d13",
     "m_Group": {
@@ -2878,6 +3287,34 @@
 
 {
     "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "4069feaa7d784755984e5ff0e5d617c7",
+    "m_Guid": {
+        "m_GuidSerialized": "407c16af-4d3b-480f-8883-a7a16fcc4df0"
+    },
+    "m_Name": "SpikeClampHeight",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "SpikeClampHeight",
+    "m_DefaultReferenceName": "_SpikeClampHeight",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 50.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
     "m_ObjectId": "42f6d847b3f54dd291b2702704a42c0f",
     "m_Guid": {
@@ -2912,6 +3349,36 @@
     "m_ShaderOutputName": "B",
     "m_StageCapability": 3,
     "m_Value": 0.0010000000474974514,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "450d5e1489b8425cb84d9d6c88b8da51",
+    "m_Id": 4,
+    "m_DisplayName": "A",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "4552c11d7871465095929250ade20d3d",
+    "m_Id": 1,
+    "m_DisplayName": "X",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "X",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
 }
@@ -3022,6 +3489,21 @@
     "m_StageCapability": 3,
     "m_Value": false,
     "m_DefaultValue": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "48ce93bd43d94364ad850be6261147ca",
+    "m_Id": 0,
+    "m_DisplayName": "SpikeClampHeight",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -3206,6 +3688,54 @@
         "y": 1.0,
         "z": 1.0,
         "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "4df495bfe0c44e70a5710c1398396881",
+    "m_Id": 1,
+    "m_DisplayName": "On",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "On",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "4e065ca7ab0648eda36107c5c9fab497",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     },
     "m_DefaultValue": {
         "x": 0.0,
@@ -3552,6 +4082,30 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "5e8c7d28cb884051a3e4688dee29940e",
+    "m_Id": 2,
+    "m_DisplayName": "False",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "False",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector2ShaderProperty",
     "m_ObjectId": "5f88a9da5718482da34a3e8bd8561f9e",
@@ -3666,6 +4220,17 @@
         "e31": 0.0,
         "e32": 0.0,
         "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.GroupData",
+    "m_ObjectId": "6487c63405774d5ca4669ee91eef53de",
+    "m_Title": "Clamp spikes in height",
+    "m_Position": {
+        "x": 10.0,
+        "y": 10.0
     }
 }
 
@@ -4090,6 +4655,23 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "70c21e8c5b3f46fcabe89c57d27c16a1",
+    "m_Id": 2,
+    "m_DisplayName": "Y",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Y",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [
+        "Y"
+    ]
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "72f8e83f81324f3cbeff04af5f638384",
     "m_Id": 2,
@@ -4097,6 +4679,30 @@
     "m_SlotType": 0,
     "m_Hidden": false,
     "m_ShaderOutputName": "False",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "73a63321e2f240df88c8f59559bfef6e",
+    "m_Id": 0,
+    "m_DisplayName": "SPIKE_CLAMPING",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
     "m_StageCapability": 3,
     "m_Value": {
         "x": 0.0,
@@ -4794,6 +5400,21 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "8f558c1929234c5387086f10f7d6d218",
+    "m_Id": 2,
+    "m_DisplayName": "G",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "G",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BooleanMaterialSlot",
     "m_ObjectId": "9150b8e4a9ad410daad3b10d8e52c009",
     "m_Id": 0,
@@ -5222,6 +5843,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "a6886d4363b144758cc451e94dcd10f4",
+    "m_Id": 0,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
     "m_ObjectId": "a6c71b0f075a48d580b60cef504868eb",
     "m_Id": 1,
@@ -5379,6 +6023,21 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "a8d7e37df107401393ca0d80c61a264a",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": 50.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BlockNode",
     "m_ObjectId": "a936ef31b7f147f0bfb2f9d4576ef359",
     "m_Group": {
@@ -5486,10 +6145,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -3067.999755859375,
-            "y": 267.0000915527344,
-            "width": 208.0,
-            "height": 277.9999084472656
+            "x": -3066.66650390625,
+            "y": 266.6667175292969,
+            "width": 209.333251953125,
+            "height": 279.9999694824219
         }
     },
     "m_Slots": [
@@ -5575,6 +6234,48 @@
     },
     "m_Labels": [],
     "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.KeywordNode",
+    "m_ObjectId": "b11cb5e542ef4a1fa13215ef06d6f5d7",
+    "m_Group": {
+        "m_Id": "6487c63405774d5ca4669ee91eef53de"
+    },
+    "m_Name": "SPIKE_CLAMPING",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 519.3333740234375,
+            "y": -596.6666259765625,
+            "width": 209.33331298828126,
+            "height": 303.9999694824219
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "73a63321e2f240df88c8f59559bfef6e"
+        },
+        {
+            "m_Id": "4df495bfe0c44e70a5710c1398396881"
+        },
+        {
+            "m_Id": "dc32eb183e3b4245b6482ed2bddc2f2c"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Keyword": {
+        "m_Id": "f335930675b84fdeb512977b7f7ee921"
+    }
 }
 
 {
@@ -5695,6 +6396,44 @@
     },
     "m_Group": {
         "m_Id": "6a4885ff20ed48ab95666d9dc9d3a68b"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BooleanMaterialSlot",
+    "m_ObjectId": "b607ea44e2b54941a2bd109a5d1c70b2",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": false,
+    "m_DefaultValue": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "b9b40170ddd442d1a57fbdc1ad3b7396",
+    "m_Id": 1,
+    "m_DisplayName": "True",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "True",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     }
 }
 
@@ -6209,6 +6948,45 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "ceb12e549b9944168f8b6390a1952f28",
+    "m_Id": 3,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "d03652eed02f4a7bacf65d09c9ed9c03",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector2ShaderProperty",
     "m_ObjectId": "d1924584f9b0482f9cd23546000465b5",
@@ -6392,6 +7170,30 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "dc32eb183e3b4245b6482ed2bddc2f2c",
+    "m_Id": 2,
+    "m_DisplayName": "Off",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Off",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
     "m_SGVersion": 2,
     "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalLitSubTarget",
     "m_ObjectId": "dc729e6434a747e3b3d3c3d17e075efb",
@@ -6435,6 +7237,52 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BranchNode",
+    "m_ObjectId": "e0c490ebde5a455d9a47b3718baca303",
+    "m_Group": {
+        "m_Id": "6487c63405774d5ca4669ee91eef53de"
+    },
+    "m_Name": "Branch",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 375.3333435058594,
+            "y": -966.0000610351563,
+            "width": 209.33328247070313,
+            "height": 328.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "3e6dfcbd03684897b23125526a7d19ab"
+        },
+        {
+            "m_Id": "b9b40170ddd442d1a57fbdc1ad3b7396"
+        },
+        {
+            "m_Id": "5e8c7d28cb884051a3e4688dee29940e"
+        },
+        {
+            "m_Id": "ceb12e549b9944168f8b6390a1952f28"
+        }
+    ],
+    "synonyms": [
+        "switch",
+        "if",
+        "else"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
 }
 
 {
@@ -6496,6 +7344,58 @@
     "m_ShaderOutputName": "Sampler",
     "m_StageCapability": 3,
     "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3Node",
+    "m_ObjectId": "e6b5b911093740168b63f16720b31cad",
+    "m_Group": {
+        "m_Id": "6487c63405774d5ca4669ee91eef53de"
+    },
+    "m_Name": "Vector 3",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 128.66671752929688,
+            "y": -828.0000610351563,
+            "width": 129.33334350585938,
+            "height": 126.6666259765625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "4552c11d7871465095929250ade20d3d"
+        },
+        {
+            "m_Id": "70c21e8c5b3f46fcabe89c57d27c16a1"
+        },
+        {
+            "m_Id": "1525cd9c95e74ec587191f20deb8abd7"
+        },
+        {
+            "m_Id": "a6886d4363b144758cc451e94dcd10f4"
+        }
+    ],
+    "synonyms": [
+        "3",
+        "v3",
+        "vec3",
+        "float3"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    }
 }
 
 {
@@ -6704,6 +7604,31 @@
 }
 
 {
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
+    "m_ObjectId": "f335930675b84fdeb512977b7f7ee921",
+    "m_Guid": {
+        "m_GuidSerialized": "4c67a6d6-7752-4aa3-991a-69d9f3c8010c"
+    },
+    "m_Name": "SPIKE_CLAMPING",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "SPIKE_CLAMPING",
+    "m_DefaultReferenceName": "_SPIKE_CLAMPING",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_KeywordType": 0,
+    "m_KeywordDefinition": 0,
+    "m_KeywordScope": 0,
+    "m_KeywordStages": 63,
+    "m_Entries": [],
+    "m_Value": 0,
+    "m_IsEditable": true
+}
+
+{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.CategoryData",
     "m_ObjectId": "f624fc9e53ad4af0b43665ff8068146f",
@@ -6759,6 +7684,12 @@
         },
         {
             "m_Id": "42f6d847b3f54dd291b2702704a42c0f"
+        },
+        {
+            "m_Id": "f335930675b84fdeb512977b7f7ee921"
+        },
+        {
+            "m_Id": "4069feaa7d784755984e5ff0e5d617c7"
         }
     ]
 }
@@ -6866,6 +7797,29 @@
     "m_Labels": [
         "X"
     ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "fe4883d8c22848398ab8516c6856975e",
+    "m_Id": 0,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
 }
 
 {


### PR DESCRIPTION
optional features ( disabled by default ) to clamp terrain spikes by pushes verts down to Y 0 if their height crosses a threshold (SpikeClampHeight)