### PR TITLE
restored slice camera event reference

### DIFF
--- a/Assets/Prefabs/Features.prefab
+++ b/Assets/Prefabs/Features.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   FeatureLinks:
-  - name: Zoeken op adres ->  (GameObject)
+  - name: Zoeken op adres -> null -> SetActive
     feature: {fileID: 11400000, guid: 3684ee2c206979e4783d50e0c07322b3, type: 2}
     onFeatureToggle:
       m_PersistentCalls:
@@ -78,9 +78,8 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-    component: {fileID: 0}
-    action: 1
-  - name: Toon gebouwen -> Buildings (GameObject)
+  - name: Toon gebouwen -> Buildings (Netherlands3D.TileSystem.BinaryMeshLayer) ->
+      set_isEnabled
     feature: {fileID: 11400000, guid: 621d91ece5b6d0145a271a1899949cdd, type: 2}
     onFeatureToggle:
       m_PersistentCalls:
@@ -97,9 +96,8 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-    component: {fileID: 6171973606309450779}
-    action: 1
-  - name: Toon het maaiveld -> Terrain (GameObject)
+  - name: Toon het maaiveld -> Terrain (Netherlands3D.TileSystem.BinaryMeshLayer)
+      -> set_isEnabled
     feature: {fileID: 11400000, guid: 388ed5cdb7e3bc94d9f8b15243890251, type: 2}
     onFeatureToggle:
       m_PersistentCalls:
@@ -116,9 +114,8 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-    component: {fileID: 2050854615230022402}
-    action: 1
-  - name: Toon namen van buurten -> NeighbourhoodNames (GameObject)
+  - name: Toon namen van buurten -> NeighbourhoodNames (Netherlands3D.TileSystem.GeoJSONTextLayer)
+      -> set_isEnabled
     feature: {fileID: 11400000, guid: cd4d713ac36eed3478e85868b1e0e0f9, type: 2}
     onFeatureToggle:
       m_PersistentCalls:
@@ -135,9 +132,8 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-    component: {fileID: 4362903983831718642}
-    action: 1
-  - name: Toon namen van wijken -> DistrictNames (GameObject)
+  - name: Toon namen van wijken -> DistrictNames (Netherlands3D.TileSystem.GeoJSONTextLayer)
+      -> set_isEnabled
     feature: {fileID: 11400000, guid: 028a24369ee97184fa88b9716c686d0d, type: 2}
     onFeatureToggle:
       m_PersistentCalls:
@@ -154,9 +150,7 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-    component: {fileID: 7077932096220116567}
-    action: 1
-  - name: Maak screenshots ->  (GameObject)
+  - name: Maak screenshots -> null -> SetActive
     feature: {fileID: 11400000, guid: ff7d5f7ae5009d24c869aa8086473845, type: 2}
     onFeatureToggle:
       m_PersistentCalls:
@@ -173,9 +167,7 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-    component: {fileID: 0}
-    action: 1
-  - name: Timeline ->  (GameObject)
+  - name: Timeline -> null -> SetActive
     feature: {fileID: 11400000, guid: 42464fdf892b6b245a26a6156b70ed6d, type: 2}
     onFeatureToggle:
       m_PersistentCalls:
@@ -192,9 +184,7 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-    component: {fileID: 0}
-    action: 1
-  - name: Verkeerssimulatie ->  (GameObject)
+  - name: Verkeerssimulatie -> null -> SetActive
     feature: {fileID: 11400000, guid: e649b402ab73d1144a36dfc3d3213136, type: 2}
     onFeatureToggle:
       m_PersistentCalls:
@@ -211,9 +201,7 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-    component: {fileID: 0}
-    action: 1
-  - name: Toon bomen -> Trees (GameObject)
+  - name: Toon bomen -> Trees (Netherlands3D.TileSystem.BinaryMeshLayer) -> set_isEnabled
     feature: {fileID: 11400000, guid: 8b0d3742935095d48941c64dd41343c0, type: 2}
     onFeatureToggle:
       m_PersistentCalls:
@@ -230,9 +218,8 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-    component: {fileID: 6122110969944145960}
-    action: 1
-  - name: Toon namen van straten -> StreetNames (GameObject)
+  - name: Toon namen van straten -> StreetNames (Netherlands3D.TileSystem.GeoJSONTextLayer)
+      -> set_isEnabled
     feature: {fileID: 11400000, guid: 2baaa0e46661c6248a5938b6b2c47544, type: 2}
     onFeatureToggle:
       m_PersistentCalls:
@@ -249,9 +236,7 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-    component: {fileID: 3118166564072164094}
-    action: 1
-  - name: Stel de zonnestand en schaduwen in ->  (GameObject)
+  - name: Stel de zonnestand en schaduwen in -> null -> SetActive
     feature: {fileID: 11400000, guid: dbd04a92726eed247b22c8dc9eb160d8, type: 2}
     onFeatureToggle:
       m_PersistentCalls:
@@ -268,9 +253,7 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-    component: {fileID: 0}
-    action: 1
-  - name: Importeer .obj bestanden ->  (GameObject)
+  - name: Importeer .obj bestanden -> null -> SetActive
     feature: {fileID: 11400000, guid: 0ec3b91944ad94ebe98ebb1e0c1b25a3, type: 2}
     onFeatureToggle:
       m_PersistentCalls:
@@ -287,9 +270,7 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-    component: {fileID: 0}
-    action: 1
-  - name: Doorzicht ondergrond ->  (GameObject)
+  - name: Doorzicht ondergrond -> null -> SetActive
     feature: {fileID: 11400000, guid: b08b1db87725f0843995bceae5d5aed6, type: 2}
     onFeatureToggle:
       m_PersistentCalls:
@@ -306,8 +287,6 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-    component: {fileID: 0}
-    action: 1
 --- !u!1001 &585138335645146675
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -783,6 +762,37 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6195754652070294114, guid: 725f556c98ca59740b61e4d90b8be46d,
+        type: 3}
+      propertyPath: createdNewPolygonArea.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6195754652070294114, guid: 725f556c98ca59740b61e4d90b8be46d,
+        type: 3}
+      propertyPath: createdNewPolygonArea.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 11400000, guid: d2662de31e988b94696535c563e12a8b,
+        type: 2}
+    - target: {fileID: 6195754652070294114, guid: 725f556c98ca59740b61e4d90b8be46d,
+        type: 3}
+      propertyPath: createdNewPolygonArea.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6195754652070294114, guid: 725f556c98ca59740b61e4d90b8be46d,
+        type: 3}
+      propertyPath: createdNewPolygonArea.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: InvokeStarted
+      objectReference: {fileID: 0}
+    - target: {fileID: 6195754652070294114, guid: 725f556c98ca59740b61e4d90b8be46d,
+        type: 3}
+      propertyPath: createdNewPolygonArea.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: Netherlands3D.Events.Vector3ListEvent, eu.netherlands3d.event-system.Runtime
+      objectReference: {fileID: 0}
+    - target: {fileID: 6195754652070294114, guid: 725f556c98ca59740b61e4d90b8be46d,
+        type: 3}
+      propertyPath: createdNewPolygonArea.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 6195754652070294141, guid: 725f556c98ca59740b61e4d90b8be46d,
         type: 3}

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -9592,22 +9592,22 @@ PrefabInstance:
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.31039372
+      value: 0.122546
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.05494828
+      value: 0.028094452
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.9344888
+      value: 0.966979
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.1654304
+      value: -0.22168611
       objectReference: {fileID: 0}
     - target: {fileID: 3919916255551741050, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
@@ -11781,27 +11781,27 @@ PrefabInstance:
     - target: {fileID: 2528326767676104237, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2528326767676104237, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2528326767676104237, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 186
       objectReference: {fileID: 0}
     - target: {fileID: 2528326767676104237, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 2528326767676104237, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -161.70001
       objectReference: {fileID: 0}
     - target: {fileID: 2563035240863271198, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
@@ -12031,27 +12031,27 @@ PrefabInstance:
     - target: {fileID: 4726940777060982362, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4726940777060982362, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4726940777060982362, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 186
       objectReference: {fileID: 0}
     - target: {fileID: 4726940777060982362, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 4726940777060982362, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -23.1
       objectReference: {fileID: 0}
     - target: {fileID: 4791696509936873103, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
@@ -12426,27 +12426,27 @@ PrefabInstance:
     - target: {fileID: 5873604667062179328, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5873604667062179328, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5873604667062179328, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 186
       objectReference: {fileID: 0}
     - target: {fileID: 5873604667062179328, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 5873604667062179328, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -207.90001
       objectReference: {fileID: 0}
     - target: {fileID: 6029444848750721631, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
@@ -12551,52 +12551,52 @@ PrefabInstance:
     - target: {fileID: 7236596875970995787, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7236596875970995787, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7236596875970995787, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 186
       objectReference: {fileID: 0}
     - target: {fileID: 7236596875970995787, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 7236596875970995787, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -115.5
       objectReference: {fileID: 0}
     - target: {fileID: 7604421221410862962, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7604421221410862962, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7604421221410862962, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 186
       objectReference: {fileID: 0}
     - target: {fileID: 7604421221410862962, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 7604421221410862962, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -69.3
       objectReference: {fileID: 0}
     - target: {fileID: 8139773757600881731, guid: 4f23765e56f13144b9405d18346ce321,
         type: 3}


### PR DESCRIPTION
fixes the profile selection tool feature. 
The Polygon selection tool events were changed; and broke the event reference. This PR restores the event reference for triggering the Slice Camera.

(large amount of changes in prefab due to OnValidate script on features object)