### PR TITLE
Change address bar when settings change

### DIFF
--- a/Assets/Plugins.meta
+++ b/Assets/Plugins.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0e79d00a9448400b8e9daeebff5e6f03
+timeCreated: 1701187626

--- a/Assets/Plugins/Jslib.meta
+++ b/Assets/Plugins/Jslib.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dde745de57a04f2485325b6192595b2a
+timeCreated: 1701187638

--- a/Assets/Plugins/Jslib/ReplaceUrl.jslib
+++ b/Assets/Plugins/Jslib/ReplaceUrl.jslib
@@ -1,0 +1,5 @@
+mergeInto(LibraryManager.library, {
+    ReplaceUrl: function (url) {
+        history.replaceState(history.state, '', UTF8ToString(url));
+    }
+});

--- a/Assets/Plugins/Jslib/ReplaceUrl.jslib.meta
+++ b/Assets/Plugins/Jslib/ReplaceUrl.jslib.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8b5814c7afc64db3896ba059b4059cd1
+timeCreated: 1701187686

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -1097,42 +1097,22 @@ PrefabInstance:
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.27437538
+      value: 0.30387002
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.02931557
+      value: 0.024735318
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.955736
+      value: 0.94925267
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.102115385
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.24651653
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0.028855028
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.96214026
-      objectReference: {fileID: 0}
-    - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.11261956
+      value: -0.0772701
       objectReference: {fileID: 0}
     - target: {fileID: 3919916255551741050, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
@@ -1736,7 +1716,7 @@ PrefabInstance:
     - target: {fileID: 70272756425911697, guid: 9963fec33e379324db2affcb3f83332f,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 45.265
       objectReference: {fileID: 0}
     - target: {fileID: 70272756425911697, guid: 9963fec33e379324db2affcb3f83332f,
         type: 3}


### PR DESCRIPTION
When the settings are changed, we want to update the address bar so that people have a deeplink they can copy and share with people.

There was also a bug updating the coordinates when clicking on the minimap; this worked in the editor, but not in the WebGL build. This has been corrected, including a bug where the altitude suddenly changed.