### PR TITLE
Fix HTML overlay alignment

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -14,7 +14,7 @@
     "com.unity.ugui": "1.0.0",
     "eu.netherlands3d.cartesiantiles": "1.0.1",
     "eu.netherlands3d.collada": "0.1.1",
-    "eu.netherlands3d.filebrowser": "2.0.0",
+    "eu.netherlands3d.filebrowser": "2.0.1",
     "eu.netherlands3d.masking": "2.0.1",
     "eu.netherlands3d.meshclipper": "https://github.com/Netherlands3D/MeshClipper.git",
     "eu.netherlands3d.obj-importer": "1.0.0",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -14,6 +14,7 @@
     "com.unity.ugui": "1.0.0",
     "eu.netherlands3d.cartesiantiles": "1.0.1",
     "eu.netherlands3d.collada": "0.1.1",
+    "eu.netherlands3d.filebrowser": "2.0.0",
     "eu.netherlands3d.masking": "2.0.1",
     "eu.netherlands3d.meshclipper": "https://github.com/Netherlands3D/MeshClipper.git",
     "eu.netherlands3d.obj-importer": "1.0.0",


### PR DESCRIPTION
- Upgrade of filebrowser package to version 2.0.1 where canvas dpi scaling is supported, so overlays align with DPI scaled canvases