### PR TITLE
Feature/minimap direct apply center

### DIFF
--- a/Assets/Scenes/SetupWizard.unity
+++ b/Assets/Scenes/SetupWizard.unity
@@ -3938,6 +3938,8 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  moveCameraToClickedLocation: 0
+  cameraMoveTarget: {fileID: 0}
 --- !u!1 &6260601659799651636
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Configuration/Configuration.cs
+++ b/Assets/Scripts/Configuration/Configuration.cs
@@ -36,8 +36,9 @@ namespace Netherlands3D.Twin.Configuration
             get => origin;
             set
             {
-                origin = value;
-                OnOriginChanged.Invoke(value);
+                var roundedValue = new Coordinate(value.CoordinateSystem, (int)value.Points[0], (int)value.Points[1], (int)value.Points[2]);
+                origin = roundedValue;
+                OnOriginChanged.Invoke(roundedValue);
             }
         }
 
@@ -126,7 +127,7 @@ namespace Netherlands3D.Twin.Configuration
         {
             var enabledFeatures = Features.Where(feature => feature.IsEnabled).Select(feature => feature.Id);
 
-            urlBuilder.AddQueryParameter("origin", $"{Origin.Points[0]},{origin.Points[1]},{origin.Points[2]}");
+            urlBuilder.AddQueryParameter("origin", $"{(int)Origin.Points[0]},{(int)origin.Points[1]},{(int)origin.Points[2]}");
             urlBuilder.AddQueryParameter("features", string.Join(',', enabledFeatures.ToArray()));
             foreach (var feature in Features)
             {

--- a/Assets/Scripts/Configuration/Configurator.cs
+++ b/Assets/Scripts/Configuration/Configurator.cs
@@ -16,6 +16,7 @@ namespace Netherlands3D.Twin.Configuration
     {
         [SerializeField] 
         private Configuration configuration;
+        public Configuration Configuration { get => configuration; }
 
         [SerializeField] 
         [Tooltip("The scene with the Setup Wizard that needs to load additively")]

--- a/Assets/Scripts/Configuration/SetupWizard.cs
+++ b/Assets/Scripts/Configuration/SetupWizard.cs
@@ -32,7 +32,7 @@ namespace Netherlands3D.Twin.Configuration
         {
             titleField.text = configuration.Title;
             titleField.onValueChanged.AddListener(value => configuration.Title = value);
-            
+
             originXField.text = configuration.Origin.Points[0].ToString(CultureInfo.InvariantCulture);
             originXField.onValueChanged.AddListener(OnOriginXChanged);
 
@@ -101,8 +101,10 @@ namespace Netherlands3D.Twin.Configuration
                 coordinate.Points[2] = currentAltitude;
             }
 
-            originXField.SetTextWithoutNotify(coordinate.Points[0].ToString(CultureInfo.InvariantCulture));
-            originYField.SetTextWithoutNotify(coordinate.Points[1].ToString(CultureInfo.InvariantCulture));
+            var roundedCoordinate = new Coordinate(CoordinateSystem.RD, (int)coordinate.Points[0], (int)coordinate.Points[1], (int)coordinate.Points[2]);
+
+            originXField.SetTextWithoutNotify(roundedCoordinate.Points[0].ToString(CultureInfo.InvariantCulture));
+            originYField.SetTextWithoutNotify(roundedCoordinate.Points[1].ToString(CultureInfo.InvariantCulture));
             configuration.Origin = coordinate;
         }
 
@@ -137,13 +139,13 @@ namespace Netherlands3D.Twin.Configuration
         private void OnOriginYChanged(string value)
         {
             int.TryParse(value, out int y);
-            configuration.Origin = new Coordinate(CoordinateSystem.RD, configuration.Origin.Points[0], y, 300);
+            configuration.Origin = new Coordinate(CoordinateSystem.RD, (int)configuration.Origin.Points[0], y, 300);
         }
 
         private void OnOriginXChanged(string value)
         {
             int.TryParse(value, out int x);
-            configuration.Origin = new Coordinate(CoordinateSystem.RD, x, configuration.Origin.Points[1], 300);
+            configuration.Origin = new Coordinate(CoordinateSystem.RD, x, (int)configuration.Origin.Points[1], 300);
         }
     }
 }

--- a/Assets/Scripts/Configuration/TileHandler/LoadRelativeCenter.cs
+++ b/Assets/Scripts/Configuration/TileHandler/LoadRelativeCenter.cs
@@ -9,19 +9,19 @@ namespace Netherlands3D.Twin.Configuration.TileHandler
 
         private void OnEnable()
         {
-            configurator.OnLoaded.AddListener(Apply);
+            configurator.Configuration.OnOriginChanged.AddListener(Apply);
         }
 
         private void OnDisable()
         {
-            configurator.OnLoaded.RemoveListener(Apply);
+            configurator.Configuration.OnOriginChanged.RemoveListener(Apply);
         }
 
-        private void Apply(Configuration configuration)
+        private void Apply(Coordinate coordinate)
         {
-            var rdCoordinates = CoordinateConverter.ConvertTo(configuration.Origin, CoordinateSystem.RD);
+            var newCoordinate = CoordinateConverter.ConvertTo(coordinate, CoordinateSystem.RD);
             // CoordinateConverter.zeroGroundLevelY = ConfigurationFile.zeroGroundLevelY;
-            EPSG7415.relativeCenter = new Vector2RD(rdCoordinates.Points[0], rdCoordinates.Points[1]);
+            EPSG7415.relativeCenter = new Vector2RD(newCoordinate.Points[0], newCoordinate.Points[1]);
         }
     }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -17,7 +17,7 @@
     "eu.netherlands3d.filebrowser": "2.0.1",
     "eu.netherlands3d.masking": "2.0.1",
     "eu.netherlands3d.meshclipper": "https://github.com/Netherlands3D/MeshClipper.git",
-    "eu.netherlands3d.minimap": "https://github.com/Netherlands3D/Minimap.git",
+    "eu.netherlands3d.minimap": "https://github.com/Netherlands3D/Minimap.git#v1.1.0",
     "eu.netherlands3d.obj-importer": "1.0.0",
     "eu.netherlands3d.selection-tools": "2.1.0",
     "eu.netherlands3d.subobjects": "1.2.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -284,11 +284,11 @@
       "hash": "0b4407a447e08aa3b5260ba6fce5934b4cfde21d"
     },
     "eu.netherlands3d.minimap": {
-      "version": "https://github.com/Netherlands3D/Minimap.git",
+      "version": "https://github.com/Netherlands3D/Minimap.git#v1.1.0",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "2f8890675543923f3cf2b773c931cc6ec18d39ba"
+      "hash": "5ed4c8b5d6e1d88ce3b5299af80cbfec1ab244ae"
     },
     "eu.netherlands3d.obj-importer": {
       "version": "1.1.0",


### PR DESCRIPTION
- Use minimap from new https://github.com/Netherlands3D/Minimap repo
- Update to new legacy netherlands3d where Minimap is removed
- Changed settings minimap to directly set relativeCenter to selected position
- Removed 'Apply' method being fired after clicking the settings complete button fixing a bug where origin was moved to wrong locations
- Changed settings RD units to rounded RD coordinates ( no decimals ) fixing bug where location could move out of bounds