### PR TITLE
ignore water geometry normals and use normal up as base normal

### DIFF
--- a/Assets/Shaders/Twin_Water.shadergraph
+++ b/Assets/Shaders/Twin_Water.shadergraph
@@ -156,6 +156,9 @@
         },
         {
             "m_Id": "327f67c5748a443fa9d1ec7dd7931180"
+        },
+        {
+            "m_Id": "a1577921643e497daf036a797b3b28e0"
         }
     ],
     "m_GroupDatas": [
@@ -430,6 +433,20 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "ca91fc9d9681e28192bc643a1589594e"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "a1577921643e497daf036a797b3b28e0"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "2819122765384aecb3d0160846036ba7"
                 },
                 "m_SlotId": 0
             }
@@ -1166,6 +1183,29 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "1bc78c0aec0e4abf9cad46de30f9b2d5",
+    "m_Id": 0,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DistanceNode",
     "m_ObjectId": "1e4c0eede8f9a88f94a0200053dc0ad5",
     "m_Group": {
@@ -1393,6 +1433,21 @@
     "m_StageCapability": 2,
     "m_Value": 0.029999999329447748,
     "m_DefaultValue": 0.5,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "2c47db4ed4ba497c8d36eb39de2bf927",
+    "m_Id": 1,
+    "m_DisplayName": "X",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "X",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
     "m_Labels": []
 }
 
@@ -2926,6 +2981,58 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3Node",
+    "m_ObjectId": "a1577921643e497daf036a797b3b28e0",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Vector 3",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 387.8231201171875,
+            "y": -223.56863403320313,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "2c47db4ed4ba497c8d36eb39de2bf927"
+        },
+        {
+            "m_Id": "cba75f5e4b34480282c6836b3d232cc6"
+        },
+        {
+            "m_Id": "b41957df642e40cfa63b1d575c3adb27"
+        },
+        {
+            "m_Id": "1bc78c0aec0e4abf9cad46de30f9b2d5"
+        }
+    ],
+    "synonyms": [
+        "3",
+        "v3",
+        "vec3",
+        "float3"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    }
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalTarget",
     "m_ObjectId": "a2d924bb017e4cafac06a5cc6c666d6a",
@@ -3249,6 +3356,23 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "b41957df642e40cfa63b1d575c3adb27",
+    "m_Id": 3,
+    "m_DisplayName": "Z",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Z",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [
+        "Z"
+    ]
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
     "m_ObjectId": "b6a684e479974b8cabbbc05ed38308a2",
@@ -3530,6 +3654,23 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "cba75f5e4b34480282c6836b3d232cc6",
+    "m_Id": 2,
+    "m_DisplayName": "Y",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Y",
+    "m_StageCapability": 3,
+    "m_Value": 1.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": [
+        "Y"
+    ]
 }
 
 {


### PR DESCRIPTION
- Ignore water geometry normals and always use normal vector up (0,1,0) for water shading

Before - After:
![image](https://github.com/Netherlands3D/twin/assets/11850024/b05f5aa3-389d-4b05-8d77-9d3a99001133)
