### PR TITLE
Deselect buildings when closing the inspector

### DIFF
--- a/Assets/Scripts/BAG/UI_BagInspector.cs
+++ b/Assets/Scripts/BAG/UI_BagInspector.cs
@@ -110,8 +110,13 @@ namespace Netherlands3D.Twin.Interface.BAG
 			}
 		}
 
+		private void OnDestroy()
+		{
+			if (selectionlayerExists)
+				GeometryColorizer.RemoveCustomColorSet(0);
+		}
 
-        public void GetBAGID(string bagID)
+		public void GetBAGID(string bagID)
 		{
 			DownloadGeoJSONProperties(new List<string>() { bagID });
 		}


### PR DESCRIPTION
When we close the inspector panel for buildings, the UI gets destroyed. Since the behaviour for coloring world objects is in this component, it made sense to undo it on destroy.