### PR TITLE
Fix minimap flickering issue if map is smaller than view bounds

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -18,7 +18,7 @@
     "eu.netherlands3d.filebrowser": "2.0.1",
     "eu.netherlands3d.masking": "2.0.1",
     "eu.netherlands3d.meshclipper": "https://github.com/Netherlands3D/MeshClipper.git",
-    "eu.netherlands3d.minimap": "1.1.0",
+    "eu.netherlands3d.minimap": "1.1.1",
     "eu.netherlands3d.obj-importer": "1.0.0",
     "eu.netherlands3d.selection-tools": "2.1.0",
     "eu.netherlands3d.subobjects": "1.2.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -284,7 +284,7 @@
       "hash": "0b4407a447e08aa3b5260ba6fce5934b4cfde21d"
     },
     "eu.netherlands3d.minimap": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {},


### PR DESCRIPTION
Use new minimap update solving flickering in map on zoom levels where the map to be smaller than the bounds