### PR TITLE
Apply initial origin from config at start 

### DIFF
--- a/Assets/Scripts/Configuration/Configuration.cs
+++ b/Assets/Scripts/Configuration/Configuration.cs
@@ -18,8 +18,7 @@ namespace Netherlands3D.Twin.Configuration
     public class Configuration : ScriptableObject, IConfiguration
     {
         [SerializeField] private string title = "Amersfoort";
-        [SerializeField] private Coordinate origin = new(CoordinateSystem.RD, 161088, 503050, 300);
-
+        [SerializeField] private Coordinate origin = new(CoordinateSystem.RD, 155207,462945, 300);
         [SerializeField] public List<Functionality> Functionalities = new();
 
         public string Title

--- a/Assets/Scripts/Configuration/SetupWizard.cs
+++ b/Assets/Scripts/Configuration/SetupWizard.cs
@@ -47,7 +47,7 @@ namespace Netherlands3D.Twin.Configuration
             addressSearchField.onCoordinateFound.AddListener(UpdateStartingPositionWithoutNotify);
             minimap.onClick.AddListener(UpdateStartingPositionWithoutNotify);
 
-            UpdateStartingPositionWithoutNotify(configuration.Origin);
+            configuration.OnOriginChanged.Invoke(configuration.Origin);
 
             foreach (var availableFunctionality in configuration.Functionalities)
             {

--- a/Assets/Scripts/Configuration/SetupWizard.cs
+++ b/Assets/Scripts/Configuration/SetupWizard.cs
@@ -47,6 +47,8 @@ namespace Netherlands3D.Twin.Configuration
             addressSearchField.onCoordinateFound.AddListener(UpdateStartingPositionWithoutNotify);
             minimap.onClick.AddListener(UpdateStartingPositionWithoutNotify);
 
+            UpdateStartingPositionWithoutNotify(configuration.Origin);
+
             foreach (var availableFunctionality in configuration.Functionalities)
             {
                 FunctionalitySelection functionalitySelection = Instantiate(functionalitySelectionPrefab, functionalitiesList.transform);


### PR DESCRIPTION
- This fixes an issue where the initial RelativeCenterRD would not be set to to the coordinates set in the configuration file. (happens when settings are closed without picking location)
- Set starting point so camera looks at Amersfoort centre 

