### PR TITLE
Add specific version of legacy nl3d to avoid cache discrepancies

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -26,7 +26,7 @@
     "eu.netherlands3d.transform-handles": "1.0.1",
     "eu.netherlands3d.web-cursors": "2.0.0",
     "eu.netherlands3d.webgl-copy-paste": "1.1.0",
-    "nl.netherlands3d": "https://github.com/Amsterdam/Netherlands3D.git?path=/Packages/Netherlands3D/",
+    "nl.netherlands3d": "https://github.com/Amsterdam/Netherlands3D.git?path=/Packages/Netherlands3D/#v3.2.0",
     "nl.netherlands3d.authentication": "https://github.com/Amsterdam/Netherlands3D.git?path=/Packages/nl.netherlands3d.authentication",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -419,7 +419,7 @@
       "url": "https://package.openupm.com"
     },
     "nl.netherlands3d": {
-      "version": "https://github.com/Amsterdam/Netherlands3D.git?path=/Packages/Netherlands3D/",
+      "version": "https://github.com/Amsterdam/Netherlands3D.git?path=/Packages/Netherlands3D/#v3.2.0",
       "depth": 0,
       "source": "git",
       "dependencies": {


### PR DESCRIPTION
 add specific version of legacy nl3d to avoid cache discrepancies between machines