### PR TITLE
Feature/transform panel percentages

### DIFF
--- a/Assets/Prefabs/ObjectLibrary/Kubus.prefab
+++ b/Assets/Prefabs/ObjectLibrary/Kubus.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &3937650689336427930
+--- !u!1 &3546580025602722566
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,11 +8,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 3322842894136088838}
-  - component: {fileID: 1834767598560659938}
-  - component: {fileID: 7188981059019938899}
-  - component: {fileID: 5613502240167318439}
-  - component: {fileID: 4985722426523753970}
+  - component: {fileID: 4654915491707622743}
+  - component: {fileID: 1753859809850613187}
+  - component: {fileID: 7766646136216359681}
   m_Layer: 0
   m_Name: Kubus
   m_TagString: Untagged
@@ -20,36 +18,36 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &3322842894136088838
+--- !u!4 &4654915491707622743
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3937650689336427930}
+  m_GameObject: {fileID: 3546580025602722566}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 10, y: 10, z: 10}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 3322842894136088838}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &1834767598560659938
+--- !u!33 &1753859809850613187
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3937650689336427930}
+  m_GameObject: {fileID: 3546580025602722566}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &7188981059019938899
+--- !u!23 &7766646136216359681
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3937650689336427930}
+  m_GameObject: {fileID: 3546580025602722566}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -85,6 +83,40 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &3937650689336427930
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3322842894136088838}
+  - component: {fileID: 5613502240167318439}
+  - component: {fileID: 4985722426523753970}
+  m_Layer: 0
+  m_Name: Kubus
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3322842894136088838
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3937650689336427930}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4654915491707622743}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &5613502240167318439
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ObjectLibrary/Trees/Amerikaanse linde.prefab
+++ b/Assets/Prefabs/ObjectLibrary/Trees/Amerikaanse linde.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &5862764184642994096
+--- !u!1 &4719628269577861061
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,11 +8,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8699527710199513864}
-  - component: {fileID: 8373204312373019516}
-  - component: {fileID: 5882979804315178889}
-  - component: {fileID: -245332181238952691}
-  - component: {fileID: 4775273902216997001}
+  - component: {fileID: 9145687947966511665}
+  - component: {fileID: 3404637967420376140}
+  - component: {fileID: 4756202189963352626}
   m_Layer: 0
   m_Name: Amerikaanse linde
   m_TagString: Untagged
@@ -20,37 +18,36 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8699527710199513864
+--- !u!4 &9145687947966511665
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5862764184642994096}
+  m_GameObject: {fileID: 4719628269577861061}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.00000008146034, y: 0.000000021855698, z: 0.000000029802317,
-    w: 1}
-  m_LocalPosition: {x: -21, y: 0, z: -1.0094794}
-  m_LocalScale: {x: 5, y: 7, z: 5}
+  m_LocalRotation: {x: -0, y: -0, z: -4.015783e-18, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 8699527710199513864}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &8373204312373019516
+--- !u!33 &3404637967420376140
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5862764184642994096}
+  m_GameObject: {fileID: 4719628269577861061}
   m_Mesh: {fileID: 8576257900391263397, guid: c2c36cc9781e646d1975d7f93ab43575, type: 3}
---- !u!23 &5882979804315178889
+--- !u!23 &4756202189963352626
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5862764184642994096}
+  m_GameObject: {fileID: 4719628269577861061}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -86,6 +83,41 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &5862764184642994096
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8699527710199513864}
+  - component: {fileID: -245332181238952691}
+  - component: {fileID: 4775273902216997001}
+  m_Layer: 0
+  m_Name: Amerikaanse linde
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8699527710199513864
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5862764184642994096}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.00000008146034, y: 0.000000021855698, z: 0.000000029802317,
+    w: 1}
+  m_LocalPosition: {x: -21, y: 0, z: -1.0094794}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9145687947966511665}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &-245332181238952691
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -105,10 +137,10 @@ CapsuleCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.25
-  m_Height: 1
+  m_Radius: 1.38
+  m_Height: 4.91
   m_Direction: 1
-  m_Center: {x: 0, y: 0.5, z: 0}
+  m_Center: {x: 0, y: 2.37, z: 0}
 --- !u!114 &4775273902216997001
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ObjectLibrary/Trees/Berk.prefab
+++ b/Assets/Prefabs/ObjectLibrary/Trees/Berk.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &8873161933895963455
+--- !u!1 &2268838825518911356
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,49 +8,46 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5588305933438712770}
-  - component: {fileID: 1151468711640090266}
-  - component: {fileID: 7480699358487618365}
-  - component: {fileID: -4152094607996323852}
-  - component: {fileID: -5241669255629115840}
+  - component: {fileID: 8279851978059484460}
+  - component: {fileID: 1354900974037171915}
+  - component: {fileID: 1330381966537878614}
   m_Layer: 0
-  m_Name: Berk
+  m_Name: BerkVisual
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5588305933438712770
+--- !u!4 &8279851978059484460
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8873161933895963455}
+  m_GameObject: {fileID: 2268838825518911356}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.00000008146034, y: 0.000000021855698, z: 0.000000029802317,
-    w: 1}
-  m_LocalPosition: {x: -5, y: 0, z: -0.009219205}
-  m_LocalScale: {x: 5, y: 7, z: 5}
+  m_LocalRotation: {x: -0, y: -0, z: -4.015783e-18, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 5588305933438712770}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &1151468711640090266
+--- !u!33 &1354900974037171915
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8873161933895963455}
+  m_GameObject: {fileID: 2268838825518911356}
   m_Mesh: {fileID: -1121266061287991961, guid: c2c36cc9781e646d1975d7f93ab43575, type: 3}
---- !u!23 &7480699358487618365
+--- !u!23 &1330381966537878614
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8873161933895963455}
+  m_GameObject: {fileID: 2268838825518911356}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -86,6 +83,41 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &8873161933895963455
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5588305933438712770}
+  - component: {fileID: -4152094607996323852}
+  - component: {fileID: -5241669255629115840}
+  m_Layer: 0
+  m_Name: Berk
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5588305933438712770
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8873161933895963455}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.00000008146034, y: 0.000000021855698, z: 0.000000029802317,
+    w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8279851978059484460}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &-4152094607996323852
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -105,10 +137,10 @@ CapsuleCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.25
-  m_Height: 1
+  m_Radius: 0.91
+  m_Height: 4.78
   m_Direction: 1
-  m_Center: {x: 0, y: 0.5, z: 0}
+  m_Center: {x: 0, y: 2.33, z: 0}
 --- !u!114 &-5241669255629115840
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ObjectLibrary/Trees/Beuk.prefab
+++ b/Assets/Prefabs/ObjectLibrary/Trees/Beuk.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &3900504088924924644
+--- !u!1 &2589031316112878485
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,11 +8,9 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4725739564332424504}
-  - component: {fileID: 4425039397101235104}
-  - component: {fileID: 7905530252888979378}
-  - component: {fileID: -1805953198364215317}
-  - component: {fileID: 1747189573281747701}
+  - component: {fileID: 4413744011563999991}
+  - component: {fileID: 8199072375765819597}
+  - component: {fileID: 2765361069406770972}
   m_Layer: 0
   m_Name: Beuk
   m_TagString: Untagged
@@ -20,37 +18,36 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4725739564332424504
+--- !u!4 &4413744011563999991
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3900504088924924644}
+  m_GameObject: {fileID: 2589031316112878485}
   serializedVersion: 2
-  m_LocalRotation: {x: 0.00000008146034, y: 0.000000021855698, z: 0.000000029802317,
-    w: 1}
-  m_LocalPosition: {x: -22, y: 0, z: -1.2640704}
-  m_LocalScale: {x: 5, y: 7, z: 5}
+  m_LocalRotation: {x: -0, y: -0, z: -4.015783e-18, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 4725739564332424504}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &4425039397101235104
+--- !u!33 &8199072375765819597
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3900504088924924644}
+  m_GameObject: {fileID: 2589031316112878485}
   m_Mesh: {fileID: 7351967134120974525, guid: c2c36cc9781e646d1975d7f93ab43575, type: 3}
---- !u!23 &7905530252888979378
+--- !u!23 &2765361069406770972
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3900504088924924644}
+  m_GameObject: {fileID: 2589031316112878485}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -86,6 +83,41 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &3900504088924924644
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4725739564332424504}
+  - component: {fileID: -1805953198364215317}
+  - component: {fileID: 1747189573281747701}
+  m_Layer: 0
+  m_Name: Beuk
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4725739564332424504
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3900504088924924644}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.00000008146034, y: 0.000000021855698, z: 0.000000029802317,
+    w: 1}
+  m_LocalPosition: {x: -22, y: 0, z: -1.2640704}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4413744011563999991}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &-1805953198364215317
 CapsuleCollider:
   m_ObjectHideFlags: 0
@@ -105,10 +137,10 @@ CapsuleCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.25
-  m_Height: 1
+  m_Radius: 1.43
+  m_Height: 4.88
   m_Direction: 1
-  m_Center: {x: 0, y: 0.5, z: 0}
+  m_Center: {x: 0, y: 2.05, z: 0}
 --- !u!114 &1747189573281747701
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ObjectLibrary/Trees/Canadapopulier.prefab
+++ b/Assets/Prefabs/ObjectLibrary/Trees/Canadapopulier.prefab
@@ -9,8 +9,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 121414271217785244}
-  - component: {fileID: 1553230379563347150}
-  - component: {fileID: 9164481796238943331}
   - component: {fileID: 8704022603555858576}
   - component: {fileID: 6927920033585568931}
   m_Layer: 0
@@ -31,26 +29,97 @@ Transform:
   m_LocalRotation: {x: 0.00000008146034, y: 0.000000021855698, z: 0.000000029802317,
     w: 1}
   m_LocalPosition: {x: -26, y: 0, z: -0.009219205}
-  m_LocalScale: {x: 5, y: 7, z: 5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 2405147691745446951}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &1553230379563347150
+--- !u!136 &8704022603555858576
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4573407623913318474}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.86
+  m_Height: 4.88
+  m_Direction: 1
+  m_Center: {x: 0, y: 2.38, z: 0}
+--- !u!114 &6927920033585568931
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4573407623913318474}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8cceefce4ff4530b78245056d126688, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  propertySectionPrefab: {fileID: 964705144372893445, guid: b2b695c4876427c439761dd2521bf672,
+    type: 3}
+--- !u!1 &5193155301075726062
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2405147691745446951}
+  - component: {fileID: 6942531740745918574}
+  - component: {fileID: 7973513463916040824}
+  m_Layer: 0
+  m_Name: Canadapopulier
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2405147691745446951
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5193155301075726062}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -4.015783e-18, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 121414271217785244}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6942531740745918574
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4573407623913318474}
+  m_GameObject: {fileID: 5193155301075726062}
   m_Mesh: {fileID: -923840513664441430, guid: c2c36cc9781e646d1975d7f93ab43575, type: 3}
---- !u!23 &9164481796238943331
+--- !u!23 &7973513463916040824
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4573407623913318474}
+  m_GameObject: {fileID: 5193155301075726062}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -86,40 +155,3 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!136 &8704022603555858576
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4573407623913318474}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.25
-  m_Height: 1
-  m_Direction: 1
-  m_Center: {x: 0, y: 0.5, z: 0}
---- !u!114 &6927920033585568931
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4573407623913318474}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b8cceefce4ff4530b78245056d126688, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  propertySectionPrefab: {fileID: 964705144372893445, guid: b2b695c4876427c439761dd2521bf672,
-    type: 3}

--- a/Assets/Prefabs/UI/Properties.prefab
+++ b/Assets/Prefabs/UI/Properties.prefab
@@ -35,8 +35,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -10, y: -50}
-  m_SizeDelta: {x: 300, y: -40}
+  m_AnchoredPosition: {x: -10, y: -10}
+  m_SizeDelta: {x: 300, y: 0}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &2002606693735210281
 MonoBehaviour:

--- a/Assets/Scripts/Layers/Properties/TransformPropertySection.cs
+++ b/Assets/Scripts/Layers/Properties/TransformPropertySection.cs
@@ -22,6 +22,8 @@ namespace Netherlands3D.Twin.Layers.Properties
         [SerializeField] private SetOfXYZ rotation = new();
         [SerializeField] private SetOfXYZ scale = new();
 
+        private const string percentageCharacter = "%";
+
         public override HierarchicalObjectLayer Layer
         {
             get => layer;
@@ -82,11 +84,11 @@ namespace Netherlands3D.Twin.Layers.Properties
         
         private void OnScaleChanged(string axisValue)
         {
-            float.TryParse(scale.xField.text, out var x);
-            float.TryParse(scale.yField.text, out var y);
-            float.TryParse(scale.zField.text, out var z);
+            float.TryParse(scale.xField.text.Replace(percentageCharacter,""), out var x);
+            float.TryParse(scale.yField.text.Replace(percentageCharacter,""), out var y);
+            float.TryParse(scale.zField.text.Replace(percentageCharacter,""), out var z);
 
-            layer.transform.localScale = new Vector3(x, y, z);
+            layer.transform.localScale = new Vector3(x / 100.0f, y / 100.0f, z / 100.0f);
         }
         
         private void UpdatePositionFields()
@@ -108,9 +110,14 @@ namespace Netherlands3D.Twin.Layers.Properties
         private void UpdateScalingFields()
         {
             var localScale = layer.transform.localScale;
-            scale.xField.SetTextWithoutNotify(localScale.x.ToString("0.00", CultureInfo.InvariantCulture));
-            scale.yField.SetTextWithoutNotify(localScale.y.ToString("0.00", CultureInfo.InvariantCulture));
-            scale.zField.SetTextWithoutNotify(localScale.z.ToString("0.00", CultureInfo.InvariantCulture));
+
+            var xPercentage = localScale.x * 100;
+            var yPercentage = localScale.y * 100;
+            var zPercentage = localScale.z * 100;
+
+            scale.xField.SetTextWithoutNotify($"{xPercentage.ToString("0.00", CultureInfo.InvariantCulture)}{percentageCharacter}");
+            scale.yField.SetTextWithoutNotify($"{yPercentage.ToString("0.00", CultureInfo.InvariantCulture)}{percentageCharacter}");
+            scale.zField.SetTextWithoutNotify($"{zPercentage.ToString("0.00", CultureInfo.InvariantCulture)}{percentageCharacter}");
         }
 
         private Coordinate ConvertLayerPositionToRd(HierarchicalObjectLayer origin)

--- a/Assets/Scripts/Layers/Properties/TransformPropertySection.cs
+++ b/Assets/Scripts/Layers/Properties/TransformPropertySection.cs
@@ -38,15 +38,15 @@ namespace Netherlands3D.Twin.Layers.Properties
         
         private void Awake()
         {
-            position.xField.onSubmit.AddListener(OnPositionChanged);
-            position.yField.onSubmit.AddListener(OnPositionChanged);
-            position.zField.onSubmit.AddListener(OnPositionChanged);
-            rotation.xField.onSubmit.AddListener(OnRotationChanged);
-            rotation.yField.onSubmit.AddListener(OnRotationChanged);
-            rotation.zField.onSubmit.AddListener(OnRotationChanged);
-            scale.xField.onSubmit.AddListener(OnScaleChanged);
-            scale.yField.onSubmit.AddListener(OnScaleChanged);
-            scale.zField.onSubmit.AddListener(OnScaleChanged);
+            position.xField.onEndEdit.AddListener(OnPositionChanged);
+            position.yField.onEndEdit.AddListener(OnPositionChanged);
+            position.zField.onEndEdit.AddListener(OnPositionChanged);
+            rotation.xField.onEndEdit.AddListener(OnRotationChanged);
+            rotation.yField.onEndEdit.AddListener(OnRotationChanged);
+            rotation.zField.onEndEdit.AddListener(OnRotationChanged);        
+            scale.xField.onValueChanged.AddListener(OnScaleChanged);
+            scale.yField.onValueChanged.AddListener(OnScaleChanged);
+            scale.zField.onValueChanged.AddListener(OnScaleChanged);
         }
 
         private void Update()
@@ -88,6 +88,8 @@ namespace Netherlands3D.Twin.Layers.Properties
             float.TryParse(scale.yField.text.Replace(percentageCharacter,""), out var y);
             float.TryParse(scale.zField.text.Replace(percentageCharacter,""), out var z);
 
+            UpdateScalingFields();
+
             layer.transform.localScale = new Vector3(x / 100.0f, y / 100.0f, z / 100.0f);
         }
         
@@ -115,9 +117,9 @@ namespace Netherlands3D.Twin.Layers.Properties
             var yPercentage = localScale.y * 100;
             var zPercentage = localScale.z * 100;
 
-            scale.xField.SetTextWithoutNotify($"{xPercentage.ToString("0.00", CultureInfo.InvariantCulture)}{percentageCharacter}");
-            scale.yField.SetTextWithoutNotify($"{yPercentage.ToString("0.00", CultureInfo.InvariantCulture)}{percentageCharacter}");
-            scale.zField.SetTextWithoutNotify($"{zPercentage.ToString("0.00", CultureInfo.InvariantCulture)}{percentageCharacter}");
+            scale.xField.SetTextWithoutNotify($"{xPercentage.ToString("0", CultureInfo.InvariantCulture)}{percentageCharacter}");
+            scale.yField.SetTextWithoutNotify($"{yPercentage.ToString("0", CultureInfo.InvariantCulture)}{percentageCharacter}");
+            scale.zField.SetTextWithoutNotify($"{zPercentage.ToString("0", CultureInfo.InvariantCulture)}{percentageCharacter}");
         }
 
         private Coordinate ConvertLayerPositionToRd(HierarchicalObjectLayer origin)


### PR DESCRIPTION
- Changed transform panel scale numbers from units to percentages
- Use onEndEdit instead of onSubmit to also apply inputs when focus is moved away from input field
- Use onValueChanged for scale inputs so scale is directly applied to give instant visual feedback
- Default all ObjectLibrary scales set to 1,1,1 ( 100% ),(except windmill, its scale is controlled by own options, and will be hidden in later update)

![image](https://github.com/Netherlands3D/twin/assets/11850024/b0d75e3e-31e3-43ce-8eec-2c76281bc8a8)

