### PR TITLE
Feature/indicator justifications

### DIFF
--- a/Assets/Prefabs/UI/Indicators/IndicatorListItem.prefab
+++ b/Assets/Prefabs/UI/Indicators/IndicatorListItem.prefab
@@ -219,7 +219,7 @@ MonoBehaviour:
   bar: {fileID: 570313339550393014}
   labelText: {fileID: 2817908787221722749}
   valueText: {fileID: 1225315705873912947}
-  informationButton: {fileID: 0}
+  informationButton: {fileID: 355644462963419581}
   minValue: 0
   maxValue: 10
   value: 6.44
@@ -442,7 +442,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 0
-  m_TargetGraphic: {fileID: 0}
+  m_TargetGraphic: {fileID: 1093693256988253357}
   m_FillRect: {fileID: 7585573630653958952}
   m_HandleRect: {fileID: 0}
   m_Direction: 0
@@ -640,19 +640,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 8706162855691591609}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: 
-        m_MethodName: 
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: 
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
 --- !u!114 &1961731509560109091
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Packages/eu.netherlands3d.indicators/Runtime/Scripts/Dossiers/Indicators/Definition.cs
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Scripts/Dossiers/Indicators/Definition.cs
@@ -3,10 +3,12 @@
 namespace Netherlands3D.Indicators.Dossiers.Indicators
 {
     [Serializable]
-    public struct Definition
+    public class Definition
     {
         public string id;
         public string name;
         public string citation;
+
+        public Justification justification;
     }
 }

--- a/Packages/eu.netherlands3d.indicators/Runtime/Scripts/Dossiers/Indicators/Justification.cs
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Scripts/Dossiers/Indicators/Justification.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Netherlands3D.Indicators.Dossiers.Indicators{
+    [Serializable]
+    public class Justification
+    {
+        public string name { get; set; } = "";
+        public string url { get; set; } = "";
+    }
+}

--- a/Packages/eu.netherlands3d.indicators/Runtime/Scripts/Dossiers/Indicators/Justification.cs.meta
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Scripts/Dossiers/Indicators/Justification.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f071cf16dd94dbe408131671fcf0762f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/eu.netherlands3d.indicators/Runtime/Scripts/UI/HorizontalBarGraph.cs
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Scripts/UI/HorizontalBarGraph.cs
@@ -56,6 +56,17 @@ namespace Netherlands3D.Indicators.UI
             }
         }
 
+        public void SetInformationButtonURL(string url)
+        {
+            if(string.IsNullOrEmpty(url))
+            {
+                informationButton.gameObject.SetActive(false);
+                return;    
+            }
+            
+            informationButton.onClick.AddListener(() => Application.OpenURL(url));
+        }
+
         public void SetFill(float value)
         {
             bar.value = value;

--- a/Packages/eu.netherlands3d.indicators/Runtime/Scripts/UI/IndicatorList.cs
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Scripts/UI/IndicatorList.cs
@@ -52,7 +52,7 @@ namespace Netherlands3D.Indicators.UI
         {
             var listItem = Instantiate(indicatorListItemPrefab, indicatorList.transform);
             var indicatorDefinition = dossierData.indicators.Find(indicator => indicator.id == indicatorId);
-
+            listItem.name = $"{indicatorId}: {indicatorDefinition.name}";
             listItem.SetLabel(indicatorDefinition.name);
             listItem.SetValue(indicatorValue, true);
             switch (alertLevel)

--- a/Packages/eu.netherlands3d.indicators/Runtime/Scripts/UI/IndicatorList.cs
+++ b/Packages/eu.netherlands3d.indicators/Runtime/Scripts/UI/IndicatorList.cs
@@ -55,6 +55,7 @@ namespace Netherlands3D.Indicators.UI
             listItem.name = $"{indicatorId}: {indicatorDefinition.name}";
             listItem.SetLabel(indicatorDefinition.name);
             listItem.SetValue(indicatorValue, true);
+            listItem.SetInformationButtonURL(indicatorDefinition.justification?.url);
             switch (alertLevel)
             {
                 case IndicatorAlertLevel.OK:


### PR DESCRIPTION
- made justification 'info' buttons optional on the indicator graph bars, based on the existence of the justification data member
- same info button now opens justification.url on click if the member exists

![image](https://github.com/Netherlands3D/twin/assets/11850024/a2cd1f73-ee70-4374-91bb-884d466d10dd)
