### PR TITLE
Added temp fix to recalculate building normals 

### DIFF
--- a/Assets/Prefabs/StandardLayers/Gebouwen.prefab
+++ b/Assets/Prefabs/StandardLayers/Gebouwen.prefab
@@ -52,7 +52,7 @@ MonoBehaviour:
   Datasets:
   - Description: 
     geoLOD: 
-    path: https://assets.netherlands3d.eu/publicassets/Buildings_2021/Buildings{x}_{y}.2.2.bin
+    path: https://assets.netherlands3d.eu/publicassets/Buildings_2023/Buildings{x}_{y}.2.2.bin
     pathQuery: 
     maximumDistance: 10000
     maximumDistanceSquared: 0

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -13,7 +13,7 @@
     "com.unity.timeline": "1.7.6",
     "com.unity.ugui": "1.0.0",
     "eu.netherlands3d.address-search": "1.1.3",
-    "eu.netherlands3d.cartesiantiles": "1.1.2",
+    "eu.netherlands3d.cartesiantiles": "https://github.com/Netherlands3D/CartesianTiles.git#feature/recalculate-mesh-normals",
     "eu.netherlands3d.collada": "0.1.1",
     "eu.netherlands3d.filebrowser": "2.0.1",
     "eu.netherlands3d.masking": "2.0.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -201,14 +201,14 @@
       "url": "https://package.openupm.com"
     },
     "eu.netherlands3d.cartesiantiles": {
-      "version": "1.1.2",
+      "version": "https://github.com/Netherlands3D/CartesianTiles.git#feature/recalculate-mesh-normals",
       "depth": 0,
-      "source": "registry",
+      "source": "git",
       "dependencies": {
         "eu.netherlands3d.coordinates": "1.2.0",
         "com.unity.textmeshpro": "3.0.6"
       },
-      "url": "https://package.openupm.com"
+      "hash": "3b805b992a2c44fa4cfc9fcf0b213aeca5b17301"
     },
     "eu.netherlands3d.collada": {
       "version": "0.1.1",


### PR DESCRIPTION
Uses temp branch in the TileHandler to fix the flat shading in Firefox and Safari.