### PR TITLE
Fixed parenting width issue

### DIFF
--- a/Assets/Prefabs/UI/Layers/LayerUI.prefab
+++ b/Assets/Prefabs/UI/Layers/LayerUI.prefab
@@ -1602,7 +1602,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &4186340492675122666
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1617,10 +1617,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 8734394992167256324}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: -34}
-  m_SizeDelta: {x: 3840, y: 4}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &4836292693583781584
 CanvasRenderer:

--- a/Assets/Scripts/Layers/LayerUI.cs
+++ b/Assets/Scripts/Layers/LayerUI.cs
@@ -270,10 +270,9 @@ namespace Netherlands3D.Twin.UI.LayerInspector
             UpdateName();
             RecalculateIndent(Layer.Depth);
             SetLayerTypeImage();
-            var maxWidth = transform.parent.GetComponent<RectTransform>().rect.width;
-            RecalculateNameWidth(maxWidth);
+            RecalculateNameWidth();
             UpdateFoldout();
-            
+
             UpdatePropertiesToggle();
         }
 
@@ -290,9 +289,7 @@ namespace Netherlands3D.Twin.UI.LayerInspector
         {
             var layerProxy = Layer as ReferencedProxyLayer;
 
-            return (layerProxy == null) 
-                ? Layer as ILayerWithProperties 
-                : layerProxy.Reference as ILayerWithProperties;
+            return (layerProxy == null) ? Layer as ILayerWithProperties : layerProxy.Reference as ILayerWithProperties;
         }
 
         private void SetLayerTypeImage()
@@ -321,8 +318,14 @@ namespace Netherlands3D.Twin.UI.LayerInspector
             layerNameField.text = Layer.name;
         }
 
-        private void RecalculateNameWidth(float maxWidth)
+        private void RecalculateNameWidth()
         {
+            var maxWidth = 0f;
+            if (ParentUI)
+                maxWidth = ParentUI.rectTransform.rect.width;
+            else
+                maxWidth = LayerBaseTransform.GetComponent<RectTransform>().rect.width;
+
             var layerNameFieldRectTransform = layerNameField.GetComponent<RectTransform>();
             var width = maxWidth;
             width -= layerNameFieldRectTransform.anchoredPosition.x;
@@ -418,7 +421,7 @@ namespace Netherlands3D.Twin.UI.LayerInspector
         public void Deselect(bool alreadyRemovedFromSelectedLayers = false)
         {
             if (propertyToggle.isOn) propertyToggle.isOn = false;
-            
+
             layerManager.SelectedLayers.Remove(this);
             Layer.OnDeselect();
             SetHighlight(InteractionState.Default);
@@ -504,7 +507,7 @@ namespace Netherlands3D.Twin.UI.LayerInspector
                     layerManager.DragLine.SetLeft(leftOffset);
 
                     newParent = referenceLayerUnderMouse.ParentUI;
-                    newSiblingIndex = referenceLayerUnderMouse.transform.GetSiblingIndex() ;
+                    newSiblingIndex = referenceLayerUnderMouse.transform.GetSiblingIndex();
 
                     if (newParent == ParentUI && newSiblingIndex > transform.GetSiblingIndex()) //account for self being included
                         newSiblingIndex--;
@@ -648,11 +651,11 @@ namespace Netherlands3D.Twin.UI.LayerInspector
         {
             // Unparent before deleting to avoid UI being destroyed multiple times (through DestroyUI and as a
             // consequence of Destroying the parent)
-            SetParent(null); 
-            
+            SetParent(null);
+
             // Make sure to remove the properties when removing the UI
             if (propertyToggle.isOn) propertyToggle.isOn = false;
-            
+
             Destroy(gameObject);
         }
 
@@ -661,7 +664,7 @@ namespace Netherlands3D.Twin.UI.LayerInspector
             propertyToggle.group = propertiesPanel.GetComponent<ToggleGroup>();
             propertyToggle.onValueChanged.AddListener((onOrOff) => ToggleProperties(onOrOff, propertiesPanel));
         }
-        
+
         private void ToggleProperties(bool onOrOff, Properties properties)
         {
             var layerWithProperties = TryFindProperties();


### PR DESCRIPTION
- set childPanel active by default so VerticalLayoutGroup will control its width
- Changed calculation of Name Width to ensure the proper maxWidth is used