### PR TITLE
Child layers no longer disappear when converting an object to a scatter layer

### DIFF
--- a/Assets/Scripts/Layers/LayerTypes/HierarchicalObjectLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/HierarchicalObjectLayer.cs
@@ -50,7 +50,7 @@ namespace Netherlands3D.Twin.Layers
 
         public void OnPointerClick(PointerEventData eventData)
         {
-            if(ReferencedProxy.UI == null) return;
+            if (ReferencedProxy.UI == null) return;
 
             ReferencedProxy.UI.Select(true);
         }
@@ -58,15 +58,15 @@ namespace Netherlands3D.Twin.Layers
         public override void OnSelect()
         {
             var transformInterfaceToggle = FindAnyObjectByType<TransformHandleInterfaceToggle>(FindObjectsInactive.Include); //todo remove FindObjectOfType
-            
-            if(transformInterfaceToggle)
+
+            if (transformInterfaceToggle)
                 transformInterfaceToggle.SetTransformTarget(gameObject);
         }
 
         public override void OnDeselect()
         {
             var transformInterfaceToggle = FindAnyObjectByType<TransformHandleInterfaceToggle>(FindObjectsInactive.Include);
-            
+
             if (transformInterfaceToggle)
                 transformInterfaceToggle.ClearTransformTarget();
         }
@@ -87,11 +87,30 @@ namespace Netherlands3D.Twin.Layers
             print("converting to scatter layer");
             var scatterLayer = new GameObject(objectLayer.name + "_Scatter");
             var layerComponent = scatterLayer.AddComponent<ObjectScatterLayer>();
-    
-            layerComponent.Initialize(objectLayer.gameObject, objectLayer.ReferencedProxy.ParentLayer as PolygonSelectionLayer, objectLayer.ReferencedProxy.ActiveSelf);
+
+            layerComponent.Initialize(objectLayer.gameObject, objectLayer.ReferencedProxy.ParentLayer as PolygonSelectionLayer, objectLayer.ReferencedProxy.ActiveSelf, UnparentDirectChildren(objectLayer.ReferencedProxy));
 
             Destroy(objectLayer); //destroy the component, not the gameObject, because we need to save the original GameObject to allow us to convert back 
             return layerComponent;
+        }
+
+        private static List<LayerNL3DBase> UnparentDirectChildren(LayerNL3DBase layer)
+        {
+            var list = new List<LayerNL3DBase>();
+            foreach (var child in layer.ChildrenLayers)
+            {
+                if (child.Depth == layer.Depth + 1)
+                {
+                    list.Add(child);
+                }
+            }
+
+            foreach (var directChild in list)
+            {
+                directChild.SetParent(null);
+            }
+
+            return list;
         }
     }
 }

--- a/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
@@ -48,6 +48,8 @@ namespace Netherlands3D.Twin.Layers
             this.originalObject = originalObject;
             this.mesh = CombineHierarchicalMeshes(originalObject.transform);
             this.material = originalObject.GetComponentInChildren<MeshRenderer>().material; //todo: make this work with multiple materials for hierarchical meshes?
+            this.material.enableInstancing = true;
+            
             polygonLayer = polygon;
 
             settings = ScriptableObject.CreateInstance<ScatterGenerationSettings>();


### PR DESCRIPTION
- When converting to a scatter layer, the children are now unparented temporarily and reparented to the new layer so they don't get destroyed in the conversion.
- Fixed material instancing when using a material that has it not enabled by default

test build:
https://cdn-dev-ams-3da.azureedge.net/autobuild/feature/disappearing-children-when-creating-scatter-layer-fix/334664329/