### PR TITLE
keep camera elevation on address change

### DIFF
--- a/Assets/Scripts/Configuration/SetupWizard.cs
+++ b/Assets/Scripts/Configuration/SetupWizard.cs
@@ -90,24 +90,28 @@ namespace Netherlands3D.Twin.Configuration
 
         public void UpdateStartingPositionWithoutNotify(Coordinate coordinate)
         {
-            var currentAltitude = configuration.Origin.Points[2];
+            var currentCameraPosition = Camera.main.transform.position;
+            var cameraCoordinateUnity = new Coordinate(CoordinateSystem.Unity, 
+                currentCameraPosition.x, 
+                currentCameraPosition.y,
+                currentCameraPosition.z
+            );
+            var cameraCoordinateRD = CoordinateConverter.ConvertTo(cameraCoordinateUnity, CoordinateSystem.RD);
+            var cameraAltitude = cameraCoordinateRD.Points[2];   
             var convertedCoordinate = CoordinateConverter.ConvertTo(coordinate, CoordinateSystem.RD);
 
-            // if Coordinate is 2D, make sure it is 3D
-            if (convertedCoordinate.Points.Length == 2)
-            {
-                convertedCoordinate = new Coordinate(
-                    convertedCoordinate.CoordinateSystem, 
-                    convertedCoordinate.Points[0], 
-                    convertedCoordinate.Points[1],
-                    currentAltitude
-                );
-            }
+            // Keep current camera elevation
+            convertedCoordinate = new Coordinate(
+                convertedCoordinate.CoordinateSystem, 
+                convertedCoordinate.Points[0], 
+                convertedCoordinate.Points[1],
+                cameraAltitude
+            );
             
             // Setting a starting position's altitude to 0 shouldn't happen, if we detect this as an artefact of
             // the conversion process or an actual intention, we reinstate the original altitude.
             if (Mathf.Approximately((float)convertedCoordinate.Points[2], 0f)) {
-                convertedCoordinate.Points[2] = currentAltitude;
+                convertedCoordinate.Points[2] = cameraAltitude;
             }
 
             var roundedCoordinate = new Coordinate(

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -807,7 +807,7 @@ PlayerSettings:
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0
   webGLDecompressionFallback: 1
-  webGLInitialMemorySize: 256
+  webGLInitialMemorySize: 64
   webGLMaximumMemorySize: 2048
   webGLMemoryGrowthMode: 2
   webGLMemoryLinearGrowthStep: 16

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -807,7 +807,7 @@ PlayerSettings:
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0
   webGLDecompressionFallback: 1
-  webGLInitialMemorySize: 64
+  webGLInitialMemorySize: 256
   webGLMaximumMemorySize: 2048
   webGLMemoryGrowthMode: 2
   webGLMemoryLinearGrowthStep: 16


### PR DESCRIPTION
- reuse current camera elevation after moving 2D coordinate via address search
- removed code that checks if coordinate has a height ( current invokers, minimap and address search both use coordinates with a height )