### PR TITLE
Added auto rotate to scatter grid in line area

### DIFF
--- a/Assets/Prefabs/StandardLayers/Gebouwen.prefab
+++ b/Assets/Prefabs/StandardLayers/Gebouwen.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 5658425303180220110}
   - component: {fileID: 6432123512545269546}
   - component: {fileID: 6531086895741313930}
+  - component: {fileID: -1780917372914214898}
   m_Layer: 7
   m_Name: Gebouwen
   m_TagString: Untagged
@@ -98,3 +99,35 @@ MonoBehaviour:
   toolThatEnablesColliders: {fileID: 11400000, guid: ca2d8a328016a5640ac4872c78c151ad,
     type: 2}
   waitForAnimationTime: 0.85
+--- !u!114 &-1780917372914214898
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4311489376399559593}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc4e15ae4a4b42ffbe4bc9b862a15a6b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  functionalities:
+  - {fileID: 11400000, guid: 621d91ece5b6d0145a271a1899949cdd, type: 2}
+  OnEnableFunctionality:
+    m_PersistentCalls:
+      m_Calls: []
+  OnDisableFunctionality:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6432123512545269546}
+        m_TargetAssemblyTypeName: Netherlands3D.Twin.ReferencedLayer, Assembly-CSharp
+        m_MethodName: DestroyLayer
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2

--- a/Assets/Prefabs/UI/PropertySections/ScatterSettingsPropertySection.prefab
+++ b/Assets/Prefabs/UI/PropertySections/ScatterSettingsPropertySection.prefab
@@ -1365,6 +1365,7 @@ MonoBehaviour:
   densitySlider: {fileID: 1757738007071709277}
   scatterSlider: {fileID: 4471605445229573455}
   angleSlider: {fileID: 5235943752098695262}
+  angleTitleLabel: {fileID: 1543947321330805619}
   heightRangeSlider: {fileID: 6027059580585128721}
   diameterRangeSlider: {fileID: 7687734465722825394}
 --- !u!1 &7402408927570306566
@@ -2652,6 +2653,12 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c7b4ed3ca1dcba245a37420ca328777d, type: 3}
+--- !u!1 &1543947321330805619 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4136261530444499954, guid: c7b4ed3ca1dcba245a37420ca328777d,
+    type: 3}
+  m_PrefabInstance: {fileID: 3173841584132497537}
+  m_PrefabAsset: {fileID: 0}
 --- !u!224 &8275993854338620794 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6832519826993315323, guid: c7b4ed3ca1dcba245a37420ca328777d,

--- a/Assets/Scripts/GridDebugger.cs
+++ b/Assets/Scripts/GridDebugger.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace Netherlands3D.Twin
+{
+    public class GridDebugger : MonoBehaviour
+    {
+        private CompoundPolygon poly;
+        private Vector2[] grid;
+        private int startIndex = 0;
+        private float angle;
+        private Bounds gridBounds;
+        [SerializeField]
+        private float cellSize = 0.5f;
+        
+        private void Start()
+        {
+            var verts = new Vector2[]
+            {
+                Vector2.zero,
+                Vector2.one * 1.5f,
+                new Vector2(0, 1)
+            };
+            poly = new CompoundPolygon(verts);
+
+            var angle = Vector2.Angle(verts[startIndex%verts.Length], verts[++startIndex%verts.Length]);
+            
+            grid = CompoundPolygon.GenerateGridPoints(poly.Bounds, cellSize, angle, out gridBounds); // we need the gridBounds out variable. 
+        }
+
+        private void Update()
+        {
+            if (Keyboard.current.kKey.wasPressedThisFrame)
+            {
+                print(startIndex);
+                
+                angle = GetAngle();
+                grid = CompoundPolygon.GenerateGridPoints(poly.Bounds, 0.5f, angle, out var gridBounds); // we need the gridBounds out variable. 
+            }
+        }
+
+        private float GetAngle()
+        {
+            var verts = poly.SolidPolygon;
+            var p0 = verts[startIndex % verts.Length];
+            var p1 = verts[++startIndex % verts.Length];
+
+            var dir = p1 - p0;
+
+            var angle = Vector2.Angle(Vector2.up, dir);
+            print(p0 + "\t" + p1 + "\t" + angle);
+            return angle;
+        }
+
+        private void OnDrawGizmos()
+        {
+            var width = Mathf.CeilToInt(1f * (gridBounds.size.x + 2 * cellSize)); //add 2*maxRandomOffset to include the max scatter range on both sides
+            var height = Mathf.CeilToInt(1f * (gridBounds.size.z + 2 * cellSize));
+            Gizmos.color = Color.yellow;
+            Gizmos.DrawWireCube(gridBounds.center, new Vector3(width, 0, height));
+            
+            //draw polygon
+            Gizmos.color = Color.cyan;
+            for (var i = 0; i < poly.SolidPolygon.Length; i++)
+            {
+                var vert = poly.SolidPolygon[i];
+                var vert3D = new Vector3(vert.x, 0, vert.y);
+
+                var nextVert = poly.SolidPolygon[(i + 1) % poly.SolidPolygon.Length];
+                var nextVert3D = new Vector3(nextVert.x, 0, nextVert.y);
+                
+                Gizmos.DrawSphere(vert3D, 0.1f);
+                Gizmos.DrawLine(vert3D, nextVert3D);
+            }
+            Gizmos.DrawWireCube(poly.Bounds.center,poly.Bounds.size);
+            
+            //draw grid
+            Gizmos.color = Color.magenta;
+            var grid3D = grid.ToVector3List();
+            foreach (var p in grid3D)
+            {
+                Gizmos.DrawSphere(p, 0.05f);
+            }
+            Gizmos.DrawWireCube(gridBounds.center, gridBounds.size);
+
+            //draw centerline
+            Gizmos.color = Color.yellow;
+            Gizmos.DrawSphere(poly.Bounds.center, 0.05f);
+            
+            var center = poly.Bounds.center;
+            Vector3 direction = Quaternion.Euler(0, -angle, 0) * Vector3.forward; // Calculate the direction of the line based on angle
+            
+            Vector3 startPoint = center - direction * (poly.Bounds.extents.magnitude / 2); // Calculate the starting point of the line
+            Vector3 endPoint = center + direction * (poly.Bounds.extents.magnitude / 2); // Calculate the end point of the line
+
+            Gizmos.DrawLine(startPoint, endPoint);
+        }
+    }
+}

--- a/Assets/Scripts/GridDebugger.cs.meta
+++ b/Assets/Scripts/GridDebugger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93693f16cd2dd4283842738be939894b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
@@ -62,6 +62,7 @@ namespace Netherlands3D.Twin.Layers
             settings.MinScale = new Vector3(3, 3, 3);
             settings.MaxScale = new Vector3(6, 6, 6);
             settings.ScatterSettingsChanged.AddListener(ResampleTexture);
+            settings.ScatterDistributionChanged.AddListener(RecalculatePolygonsAndSamplerTexture);
             settings.ScatterShapeChanged.AddListener(RecalculatePolygonsAndSamplerTexture);
             propertySections = new List<IPropertySectionInstantiator>() { settings };
 
@@ -92,6 +93,7 @@ namespace Netherlands3D.Twin.Layers
         {
             base.OnDestroy();
             settings.ScatterSettingsChanged.RemoveListener(ResampleTexture);
+            settings.ScatterDistributionChanged.RemoveListener(RecalculatePolygonsAndSamplerTexture);
             settings.ScatterShapeChanged.RemoveListener(RecalculatePolygonsAndSamplerTexture);
             polygonLayer.polygonChanged.RemoveListener(RecalculatePolygonsAndSamplerTexture);
         }

--- a/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
@@ -55,7 +55,7 @@ namespace Netherlands3D.Twin.Layers
             settings.Density = 1000; // per ha for the UI
             if (polygon.ShapeType == ShapeType.Line)
             {
-                settings.Angle = CalculateLineAngle(polygon);
+                settings.Angle = -1; //set angle to a value outside of the 0-180 range of Vector2.Angle in CalculateLineAngle(), because this will ensure the onchange event to be called when initializing the first time in SetAngleAndUpdateSampleTexture
                 settings.AutoRotateToLine = true;
             }
 
@@ -133,18 +133,6 @@ namespace Netherlands3D.Twin.Layers
 
         private void RecalculatePolygonsAndSamplerTexture()
         {
-            if (polygonLayer.ShapeType == ShapeType.Line)
-            {
-                var newAngle = CalculateLineAngle(polygonLayer);
-                
-                //Avoid calling the code below twice, once through the polygon edit event, and once because of the settings change event (since the angle is set).
-                if (!Mathf.Approximately(settings.Angle, newAngle)) 
-                {
-                    settings.Angle = newAngle; //this will call the change event, which will result in this function be called again but this time this if block won't be reached and we can continue with the polygon recalculation.
-                    return; 
-                }
-            }
-
             RecalculatePolygonsAndGetBounds();
             if (polygonBounds.size.sqrMagnitude == 0)
                 return; // the stroke/fill is clipped out because of the stroke width and no further processing is needed

--- a/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
@@ -61,7 +61,7 @@ namespace Netherlands3D.Twin.Layers
 
             settings.MinScale = new Vector3(3, 3, 3);
             settings.MaxScale = new Vector3(6, 6, 6);
-            settings.ScatterSettingsChanged.AddListener(RecalculatePolygonsAndSamplerTexture); //todo: when scatter settings change, the polygons don't always need to be recalculated, but in case of a density change it does, because the sample texture should have a different resolution.
+            settings.ScatterSettingsChanged.AddListener(ResampleTexture);
             settings.ScatterShapeChanged.AddListener(RecalculatePolygonsAndSamplerTexture);
             propertySections = new List<IPropertySectionInstantiator>() { settings };
 

--- a/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
@@ -150,6 +150,9 @@ namespace Netherlands3D.Twin.Layers
 
         private Bounds RecalculatePolygonsAndGetBounds()
         {
+            if (polygonLayer.ShapeType == ShapeType.Line)
+                settings.Angle = CalculateLineAngle(polygonLayer);
+            
             var polygons = CalculateAndVisualisePolygons(polygonLayer.Polygon);
             if (polygons.Count == 0)
                 return new Bounds(); // the stroke/fill is clipped out because of the stroke width and no further processing is needed

--- a/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
@@ -23,7 +23,7 @@ namespace Netherlands3D.Twin.Layers
         private ScatterGenerationSettings settings;
         public ScatterGenerationSettings Settings => settings;
         private Matrix4x4[][] matrixBatches; //Graphics.DrawMeshInstanced can only draw 1023 instances at once, so we use a 2d array to batch the matrices
-        private PolygonSelectionLayer polygonLayer;
+        public PolygonSelectionLayer polygonLayer;
         private List<IPropertySectionInstantiator> propertySections = new();
         private List<PolygonVisualisation> visualisations = new();
 
@@ -81,6 +81,10 @@ namespace Netherlands3D.Twin.Layers
             polygon.polygonChanged.AddListener(RecalculatePolygonsAndSamplerTexture);
             ReferencedProxy.ActiveSelf = initialActiveState; //set to same state as current layer
 
+#if UNITY_EDITOR
+            gameObject.AddComponent<GridDebugger>();
+#endif
+            
             completedInitialization = true;
         }
 

--- a/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
@@ -61,7 +61,7 @@ namespace Netherlands3D.Twin.Layers
 
             settings.MinScale = new Vector3(3, 3, 3);
             settings.MaxScale = new Vector3(6, 6, 6);
-            settings.ScatterSettingsChanged.AddListener(ResampleTexture);
+            settings.ScatterSettingsChanged.AddListener(RecalculatePolygonsAndSamplerTexture); //todo: when scatter settings change, the polygons don't always need to be recalculated, but in case of a density change it does, because the sample texture should have a different resolution.
             settings.ScatterShapeChanged.AddListener(RecalculatePolygonsAndSamplerTexture);
             propertySections = new List<IPropertySectionInstantiator>() { settings };
 

--- a/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/ObjectScatterLayer.cs
@@ -167,7 +167,7 @@ namespace Netherlands3D.Twin.Layers
                 var polygon = polygons[index];
                 bounds.Encapsulate(polygon.Bounds);
             }
-
+            
             polygonBounds = bounds;
             return bounds;
         }
@@ -176,9 +176,9 @@ namespace Netherlands3D.Twin.Layers
         {
             var densityPerSquareUnit = settings.Density / 10000; //in de UI is het het bomen per hectare, in de functie is het punten per m2
             float cellSize = 1f / Mathf.Sqrt(densityPerSquareUnit);
-            var gridPoints = CompoundPolygon.GenerateGridPoints(polygonBounds, cellSize, settings.Angle, out var gridBounds);
+            var gridPoints = CompoundPolygon.GenerateGridPoints(polygonBounds, cellSize, 0, out var gridBounds); //dont rotate the grid here, we will rotate the results after sampling to avoid issues with anti-aliassing
             var normalizedScatter = settings.Scatter / 100f;
-            ScatterMap.Instance.SampleTexture(sampleTexture, gridPoints, gridBounds, normalizedScatter, cellSize, ProcessScatterPoints);
+            ScatterMap.Instance.SampleTexture(sampleTexture, gridPoints, gridBounds, normalizedScatter, cellSize, settings.Angle, ProcessScatterPoints);
         }
 
         private void ProcessScatterPoints(List<Vector3> scatterPoints, List<Vector2> sampledScales)

--- a/Assets/Scripts/Layers/LayerTypes/PolygonSelectionLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/PolygonSelectionLayer.cs
@@ -120,8 +120,11 @@ namespace Netherlands3D.Twin.Layers
 
             RecalculateLineWidth(line, lineWidth);
 
-            var lineProperties = gameObject.AddComponent<PolygonPropertySectionInstantiator>();
-            propertySections = new List<IPropertySectionInstantiator>() { lineProperties };
+            if (propertySections.Count == 0)
+            {
+                var lineProperties = gameObject.AddComponent<PolygonPropertySectionInstantiator>();
+                propertySections = new List<IPropertySectionInstantiator>() { lineProperties };
+            }
             // Properties.Properties.Instance.Show(this);
         }
 

--- a/Assets/Scripts/Layers/Properties/ScatterSettingsPropertySection.cs
+++ b/Assets/Scripts/Layers/Properties/ScatterSettingsPropertySection.cs
@@ -19,6 +19,7 @@ namespace Netherlands3D.Twin.Layers.Properties
         [SerializeField] private Slider densitySlider;
         [SerializeField] private Slider scatterSlider;
         [SerializeField] private Slider angleSlider;
+        [SerializeField] private GameObject angleTitleLabel;
         [SerializeField] private DoubleSlider heightRangeSlider;
         [SerializeField] private DoubleSlider diameterRangeSlider;
 
@@ -39,10 +40,21 @@ namespace Netherlands3D.Twin.Layers.Properties
                 densitySlider.value = settings.Density;
                 scatterSlider.value = settings.Scatter; 
                 angleSlider.value = settings.Angle;
+                ShowAngleSlider = !settings.AutoRotateToLine;
                 heightRangeSlider.minSliderValue = settings.MinScale.y;
                 heightRangeSlider.maxSliderValue = settings.MaxScale.y;
                 diameterRangeSlider.minSliderValue = settings.MinScale.x; //x and z are the same for diameter
                 diameterRangeSlider.maxSliderValue = settings.MaxScale.x;
+            }
+        }
+
+        public bool ShowAngleSlider
+        {
+            get => angleSlider.gameObject.activeSelf;
+            set
+            {
+                angleSlider.gameObject.SetActive(value);
+                angleTitleLabel.gameObject.SetActive(value);
             }
         }
 

--- a/Assets/Scripts/Layers/ScatterGenerationSettings.cs
+++ b/Assets/Scripts/Layers/ScatterGenerationSettings.cs
@@ -34,7 +34,7 @@ namespace Netherlands3D.Twin
                     return;
 
                 density = value;
-                ScatterSettingsChanged.Invoke();
+                ScatterShapeChanged.Invoke(); //changing the density requires a rerender of the shape because of the resolution change
             }
         }
 

--- a/Assets/Scripts/Layers/ScatterGenerationSettings.cs
+++ b/Assets/Scripts/Layers/ScatterGenerationSettings.cs
@@ -22,15 +22,17 @@ namespace Netherlands3D.Twin
 
         public UnityEvent ScatterSettingsChanged = new UnityEvent(); //called when the settings of the to be scattered objects change, without needing to regenerate the sampler texture
         public UnityEvent ScatterShapeChanged = new UnityEvent(); //called when the settings of the shape should change, thereby needing a regenerating of the sampler texture
-        
+
+        public bool AutoRotateToLine { get; set; } = false;
+
         public float Density
         {
             get { return density; }
             set
             {
-                if(density == value)
+                if (density == value)
                     return;
-                
+
                 density = value;
                 ScatterSettingsChanged.Invoke();
             }
@@ -41,9 +43,9 @@ namespace Netherlands3D.Twin
             get { return scatter; }
             set
             {
-                if(scatter == value)
+                if (scatter == value)
                     return;
-                
+
                 scatter = value;
                 ScatterSettingsChanged.Invoke();
             }
@@ -54,65 +56,66 @@ namespace Netherlands3D.Twin
             get { return angle; }
             set
             {
-                if(angle == value)
+                if (angle == value)
                     return;
-                
+
                 angle = value;
                 ScatterSettingsChanged.Invoke();
             }
         }
-        
+
         public Vector3 MinScale
         {
             get { return minScale; }
             set
             {
-                if(minScale == value)
+                if (minScale == value)
                     return;
-                
+
                 minScale = value;
                 ScatterSettingsChanged.Invoke();
             }
         }
-        
+
         public Vector3 MaxScale
         {
             get { return maxScale; }
             set
             {
-                if(maxScale == value)
+                if (maxScale == value)
                     return;
-                
+
                 maxScale = value;
                 ScatterSettingsChanged.Invoke();
             }
         }
-        
+
         public FillType FillType
         {
             get => fillType;
             set
             {
-                if(fillType == value)
+                if (fillType == value)
                     return;
-                
+
                 fillType = value;
                 ScatterShapeChanged.Invoke();
-            } 
-        } 
+            }
+        }
+
         public float StrokeWidth
         {
             get => strokeWidth;
             set
             {
-                if(strokeWidth == value)
+                if (strokeWidth == value)
                     return;
-                
+
                 strokeWidth = value;
                 ScatterShapeChanged.Invoke();
             }
         }
-        
+
         public Vector3 GenerateRandomScale()
         {
             float x = UnityEngine.Random.Range(minScale.x, maxScale.x);
@@ -121,7 +124,7 @@ namespace Netherlands3D.Twin
 
             return new Vector3(x, y, z);
         }
-        
+
         public void AddToProperties(RectTransform properties)
         {
             var propertySection = Instantiate(ScatterMap.Instance.propertyPanelPrefab, properties);

--- a/Assets/Scripts/Layers/ScatterGenerationSettings.cs
+++ b/Assets/Scripts/Layers/ScatterGenerationSettings.cs
@@ -22,6 +22,7 @@ namespace Netherlands3D.Twin
 
         public UnityEvent ScatterSettingsChanged = new UnityEvent(); //called when the settings of the to be scattered objects change, without needing to regenerate the sampler texture
         public UnityEvent ScatterShapeChanged = new UnityEvent(); //called when the settings of the shape should change, thereby needing a regenerating of the sampler texture
+        public UnityEvent ScatterDistributionChanged = new UnityEvent(); //called when the settings of the shape should change, thereby needing a regenerating of the sampler texture
 
         public bool AutoRotateToLine { get; set; } = false;
 
@@ -34,7 +35,7 @@ namespace Netherlands3D.Twin
                     return;
 
                 density = value;
-                ScatterShapeChanged.Invoke(); //changing the density requires a rerender of the shape because of the resolution change
+                ScatterDistributionChanged.Invoke(); 
             }
         }
 
@@ -60,7 +61,7 @@ namespace Netherlands3D.Twin
                     return;
 
                 angle = value;
-                ScatterSettingsChanged.Invoke();
+                ScatterDistributionChanged.Invoke();
             }
         }
 

--- a/Assets/Scripts/Samplers/ScatterMap.cs
+++ b/Assets/Scripts/Samplers/ScatterMap.cs
@@ -106,10 +106,10 @@ namespace Netherlands3D.Twin
         private IEnumerator GenerateScatterPointsCoroutine(List<PolygonVisualisation> visualisations, Bounds polygonBounds, float density, float scatter, float angle, Action<SampleTexture> onSamplerTextureCreated)
         {
             float cellSize = 1f / Mathf.Sqrt(density);
-            polyBounds = polygonBounds;
             CompoundPolygon.GenerateGridPoints(polygonBounds, cellSize, angle, out var gridBounds); // we need the gridBounds out variable. 
 
 #if UNITY_EDITOR
+            this.polyBounds = polygonBounds;
             this.gridBounds = gridBounds;
             this.gridCellSize = cellSize;
 #endif

--- a/Assets/Scripts/Samplers/ScatterMap.cs
+++ b/Assets/Scripts/Samplers/ScatterMap.cs
@@ -106,6 +106,7 @@ namespace Netherlands3D.Twin
         private IEnumerator GenerateScatterPointsCoroutine(List<PolygonVisualisation> visualisations, Bounds polygonBounds, float density, float scatter, float angle, Action<SampleTexture> onSamplerTextureCreated)
         {
             float cellSize = 1f / Mathf.Sqrt(density);
+            polyBounds = polygonBounds;
             CompoundPolygon.GenerateGridPoints(polygonBounds, cellSize, angle, out var gridBounds); // we need the gridBounds out variable. 
 
 #if UNITY_EDITOR

--- a/Assets/Scripts/Samplers/ScatterMap.cs
+++ b/Assets/Scripts/Samplers/ScatterMap.cs
@@ -119,9 +119,9 @@ namespace Netherlands3D.Twin
             {
                 visualisation.gameObject.SetActive(true); //enable all visualisations and disable them again when done, to avoid visualisations showing up in other textures
             }
-            
+
             CreateRenderTexture(gridBounds, GridSampleSize); //todo: polygon should be rendered with an outline to include the random offset of points outside the polygon that due to the random offset will be shifted inside the polygon.
-            AlignCameraToPolygon(depthCamera, gridBounds);
+            AlignCameraToPolygon(depthCamera, gridBounds, angle);
 
             yield return null; //wait for next frame to begin rendering with the new settings
             RenderDepthCamera(); //don't know exactly why it is needed to wait twice, but not doing so causes unexpected behaviour
@@ -129,7 +129,7 @@ namespace Netherlands3D.Twin
 
             var texture = new SampleTexture(samplerTexture);
             Destroy(samplerTexture);
-            
+
             onSamplerTextureCreated.Invoke(texture);
             foreach (var visualisation in visualisations)
             {
@@ -144,11 +144,11 @@ namespace Netherlands3D.Twin
                 scatterCoroutine = StartCoroutine(coroutineQueue.Dequeue());
             }
         }
-        
-        public void SampleTexture(SampleTexture sampleTexture, Vector2[] gridPoints, Bounds gridBounds, float scatter, float cellSize, Action<List<Vector3>, List<Vector2>> onPointsGeneratedCallback)
+
+        public void SampleTexture(SampleTexture sampleTexture, Vector2[] gridPoints, Bounds gridBounds, float scatter, float cellSize, float angle, Action<List<Vector3>, List<Vector2>> onPointsGeneratedCallback)
         {
             //sample texture at points to get random offset and add random offset to world space points. Sample texture at new point to see if it is inside the poygon and if so to get the height.
-            var offsetPoints = AddRandomOffsetAndSampleHeightAndSampleScale(sampleTexture, gridPoints, gridBounds, GridSampleSize, scatter, cellSize);
+            var offsetPoints = AddRandomOffsetAndSampleHeightAndSampleScale(sampleTexture, gridPoints, gridBounds, GridSampleSize, scatter, cellSize, angle);
             onPointsGeneratedCallback?.Invoke(offsetPoints.Item1, offsetPoints.Item2);
         }
 
@@ -175,7 +175,7 @@ namespace Netherlands3D.Twin
         /// <param name="randomness">How much scatter to apply in a Range from 0 (no scatter) to 1 (max scatter)</param>
         /// <param name="gridCellSize">size of a single grid cell</param>
         /// <returns>List of offset points with the sampled height and the raw random sample at the offset point</returns>
-        private (List<Vector3>, List<Vector2>) AddRandomOffsetAndSampleHeightAndSampleScale(SampleTexture texture, Vector2[] worldPoints, Bounds gridBounds, float gridSampleSize, float randomness, float gridCellSize)
+        private (List<Vector3>, List<Vector2>) AddRandomOffsetAndSampleHeightAndSampleScale(SampleTexture texture, Vector2[] worldPoints, Bounds gridBounds, float gridSampleSize, float randomness, float gridCellSize, float angle)
         {
             var points = new List<Vector3>(worldPoints.Length);
             var sampledScales = new List<Vector2>(worldPoints.Length);
@@ -189,6 +189,11 @@ namespace Netherlands3D.Twin
             var textureHeight = texture.height;
             var offsetPoint = new Vector3(); //define vector3 here to avoid calling constructor in the (potentially large) loop
             var sampledRandomness = new Vector2();
+
+
+            float angleRad = angle * Mathf.Deg2Rad;
+            float sinAngle = Mathf.Sin(angleRad);
+            float cosAngle = Mathf.Cos(angleRad);
 
             for (int i = 0; i < worldPoints.Length; i++)
             {
@@ -223,9 +228,18 @@ namespace Netherlands3D.Twin
                 if (newColorSample.a < 0.5f) //new sampled color does not have an alpha value, so it falls outside of the polygon. Therefore this point can be skipped. This wil clip out any points outside of the polygon
                     continue;
 
-                offsetPoint.x = scatteredPointX;
+                // Translate point relative to rotation center
+                float translatedX = scatteredPointX - boundsCenter2D.x;
+                float translatedY = scatteredPointY - boundsCenter2D.y;
+
+                // Rotate point using Isine and cosine
+                float rotatedX = translatedX * cosAngle - translatedY * sinAngle;
+                float rotatedY = translatedX * sinAngle + translatedY * cosAngle;
+
+                // Translate back to original position
+                offsetPoint.x = rotatedX + boundsCenter2D.x;
                 offsetPoint.y = newColorSample.b;
-                offsetPoint.z = scatteredPointY;
+                offsetPoint.z = rotatedY + boundsCenter2D.y;
 
                 sampledRandomness.x = newColorSample.r; //for our purposes, it doesn't really matter if these use the same sampled values as for the random offset
                 sampledRandomness.y = newColorSample.g;
@@ -259,9 +273,10 @@ namespace Netherlands3D.Twin
         /// </summary>
         /// <param name="camera">Camera to align. The camera must be orthographic to set the size properly</param>
         /// <param name="bounds">Polygon to align to. The camera orthographic size will be set to the polygon height (z) value.</param>
-        public void AlignCameraToPolygon(Camera camera, Bounds bounds)
+        public void AlignCameraToPolygon(Camera camera, Bounds bounds, float angle)
         {
             camera.transform.position = new Vector3(bounds.center.x, camera.transform.position.y, bounds.center.z);
+            camera.transform.rotation = Quaternion.Euler(90, 0, angle);
             camera.orthographicSize = bounds.extents.z;
         }
     }


### PR DESCRIPTION
- Scatter grid is now auto rotated to the line angle (first two points)
- Angle setting is not available in line scatter areas
- fixed minor bug that buildings prefab was not linked to the functionality event, like the other tile prefabs

test build: https://cdn-dev-ams-3da.azureedge.net/autobuild/feature/rotate-scatter-grid-to-line-orientation/339627371/
