### PR TITLE
added new lod 1.2 and 2.2 datasets for buildings

### DIFF
--- a/Assets/Prefabs/StandardLayers/Gebouwen.prefab
+++ b/Assets/Prefabs/StandardLayers/Gebouwen.prefab
@@ -53,9 +53,16 @@ MonoBehaviour:
   Datasets:
   - Description: 
     geoLOD: 
-    path: https://assets.netherlands3d.eu/publicassets/Buildings_2023/Buildings{x}_{y}.2.2.bin
+    path: https://assets.netherlands3d.eu/publicassets/Buildings_2023_LOD12/buildings-{x}_{y}.1.2.bin
     pathQuery: 
     maximumDistance: 10000
+    maximumDistanceSquared: 0
+    enabled: 1
+  - Description: 
+    geoLOD: 
+    path: https://assets.netherlands3d.eu/publicassets/Buildings_2023_LOD22/buildings-{x}_{y}.2.2.bin
+    pathQuery: 
+    maximumDistance: 3000
     maximumDistanceSquared: 0
     enabled: 1
   pauseLoading: 0

--- a/Assets/Prefabs/StandardLayers/Gebouwen.prefab
+++ b/Assets/Prefabs/StandardLayers/Gebouwen.prefab
@@ -53,14 +53,14 @@ MonoBehaviour:
   Datasets:
   - Description: 
     geoLOD: 
-    path: https://assets.netherlands3d.eu/publicassets/Buildings_2023_LOD12/buildings-{x}_{y}.1.2.bin
+    path: https://assets.netherlands3d.eu/publicassets/3dbag/2024.02.28/lod1.2/buildings-{x}_{y}.1.2.bin
     pathQuery: 
     maximumDistance: 10000
     maximumDistanceSquared: 0
     enabled: 1
   - Description: 
     geoLOD: 
-    path: https://assets.netherlands3d.eu/publicassets/Buildings_2023_LOD22/buildings-{x}_{y}.2.2.bin
+    path: https://assets.netherlands3d.eu/publicassets/3dbag/2024.02.28/lod2.2/buildings-{x}_{y}.2.2.bin
     pathQuery: 
     maximumDistance: 3000
     maximumDistanceSquared: 0

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -13,7 +13,7 @@
     "com.unity.timeline": "1.7.6",
     "com.unity.ugui": "1.0.0",
     "eu.netherlands3d.address-search": "1.1.3",
-    "eu.netherlands3d.cartesiantiles": "https://github.com/Netherlands3D/CartesianTiles.git#feature/recalculate-mesh-normals",
+    "eu.netherlands3d.cartesiantiles": "1.1.2",
     "eu.netherlands3d.collada": "0.1.1",
     "eu.netherlands3d.filebrowser": "2.0.1",
     "eu.netherlands3d.masking": "2.0.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -201,14 +201,14 @@
       "url": "https://package.openupm.com"
     },
     "eu.netherlands3d.cartesiantiles": {
-      "version": "https://github.com/Netherlands3D/CartesianTiles.git#feature/recalculate-mesh-normals",
+      "version": "1.1.2",
       "depth": 0,
-      "source": "git",
+      "source": "registry",
       "dependencies": {
         "eu.netherlands3d.coordinates": "1.2.0",
         "com.unity.textmeshpro": "3.0.6"
       },
-      "hash": "3b805b992a2c44fa4cfc9fcf0b213aeca5b17301"
+      "url": "https://package.openupm.com"
     },
     "eu.netherlands3d.collada": {
       "version": "0.1.1",


### PR DESCRIPTION
- use openupm Cartesian Tiles package instead of .git feature branch with temporary 'missing normals' fix 
- changed Buildings path to new dataset generated from 3DBag v2024.02.28 with normals and removed problematic holes
- added extra LOD level for buildings using 3DBag [LOD1.2](https://3d.bk.tudelft.nl/lod/)