### PR TITLE
Feature/polygon height

### DIFF
--- a/Assets/Materials/PolygonDecal.mat
+++ b/Assets/Materials/PolygonDecal.mat
@@ -1,0 +1,142 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-5268460438910183700
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PolygonDecal
+  m_Shader: {fileID: -6465566751694194690, guid: 9b4e681081e2b4c469111bb649e2f7ee,
+    type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 1
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - Base_Map:
+        m_Texture: {fileID: 8400000, guid: b858922351e2e427780c2ced9f2e0a46, type: 2}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - Normal_Map:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - Normal_Blend: 0.5
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DecalMeshBiasType: 0
+    - _DecalMeshDepthBias: 0
+    - _DecalMeshViewBias: 0
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DrawOrder: 0
+    - _DstBlend: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Materials/PolygonDecal.mat.meta
+++ b/Assets/Materials/PolygonDecal.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2af29ec81e9884f66870fe0c48ac0943
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/PolygonVisualisation.mat
+++ b/Assets/Materials/PolygonVisualisation.mat
@@ -130,8 +130,8 @@ Material:
     - _WorkflowMode: 1
     - _ZWrite: 0
     m_Colors:
-    - _BaseColor: {r: 0.5882353, g: 0.93333334, b: 1, a: 0.13333334}
-    - _Color: {r: 0.5882353, g: 0.93333334, b: 1, a: 0.13333334}
+    - _BaseColor: {r: 0.5882353, g: 0.93333334, b: 1, a: 0.44705883}
+    - _Color: {r: 0.5882353, g: 0.93333334, b: 1, a: 0.44705883}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Materials/PolygonVisualisation.mat
+++ b/Assets/Materials/PolygonVisualisation.mat
@@ -1,0 +1,137 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-578853740908196598
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PolygonVisualisation
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _RECEIVE_SHADOWS_OFF
+  - _SURFACE_TYPE_TRANSPARENT
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses:
+  - SHADOWCASTER
+  - DepthOnly
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 0
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 10
+    - _DstBlendAlpha: 10
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 0
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 5
+    - _SrcBlendAlpha: 1
+    - _Surface: 1
+    - _WorkflowMode: 1
+    - _ZWrite: 0
+    m_Colors:
+    - _BaseColor: {r: 0.5882353, g: 0.93333334, b: 1, a: 0.13333334}
+    - _Color: {r: 0.5882353, g: 0.93333334, b: 1, a: 0.13333334}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Materials/PolygonVisualisation.mat
+++ b/Assets/Materials/PolygonVisualisation.mat
@@ -21,11 +21,10 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: PolygonVisualisation
-  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Shader: {fileID: 4800000, guid: 650dd9526735d5b46b79224bc6e94025, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
-  - _RECEIVE_SHADOWS_OFF
   - _SURFACE_TYPE_TRANSPARENT
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -103,6 +102,7 @@ Material:
     - _AlphaToMask: 0
     - _Blend: 0
     - _BlendModePreserveSpecular: 0
+    - _BlendOp: 0
     - _BumpScale: 1
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
@@ -121,6 +121,7 @@ Material:
     - _Parallax: 0.005
     - _QueueOffset: 0
     - _ReceiveShadows: 0
+    - _SampleGI: 0
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
@@ -130,8 +131,8 @@ Material:
     - _WorkflowMode: 1
     - _ZWrite: 0
     m_Colors:
-    - _BaseColor: {r: 0.5882353, g: 0.93333334, b: 1, a: 0.44705883}
-    - _Color: {r: 0.5882353, g: 0.93333334, b: 1, a: 0.44705883}
+    - _BaseColor: {r: 0.5882353, g: 0.93333334, b: 1, a: 0.3764706}
+    - _Color: {r: 0.5882353, g: 0.93333334, b: 1, a: 0.3764706}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Materials/PolygonVisualisation.mat.meta
+++ b/Assets/Materials/PolygonVisualisation.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c7fb2e346bb0d4f6da1f26f4c0bcf533
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/CustomLayers/PolygonInputToLayer.prefab
+++ b/Assets/Prefabs/CustomLayers/PolygonInputToLayer.prefab
@@ -471,8 +471,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   polygonExtrusionHeight: 10
   polygonMeshMaterial: {fileID: 2100000, guid: 44d459479e0340446b1215b3f6901764, type: 2}
-  polygonInput: {fileID: 5035265957184785309}
-  lineInput: {fileID: 7857407149832917040}
+  polygonInput: {fileID: 2971444630074657358}
+  lineInput: {fileID: 6819746166564945398}
   defaultLineWidth: 10
   polygonPropertySectionPrefab: {fileID: 3186418061294983386, guid: 599137b5f8b96463dbf2bd16d71cd26d,
     type: 3}
@@ -526,7 +526,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &2125279392852574923
 Transform:
   m_ObjectHideFlags: 0
@@ -553,7 +553,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5035265957184785311}
   - component: {fileID: 5035265957184785308}
-  - component: {fileID: 5035265957184785309}
+  - component: {fileID: 2971444630074657358}
   m_Layer: 0
   m_Name: PolygonSelection_Polygon
   m_TagString: Untagged
@@ -683,7 +683,7 @@ LineRenderer:
   m_UseWorldSpace: 1
   m_Loop: 0
   m_ApplyActiveColorSpace: 0
---- !u!114 &5035265957184785309
+--- !u!114 &2971444630074657358
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -692,12 +692,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 5035265957184785282}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0e0e5a1aab0d69a4fb6831b226ee84c7, type: 3}
+  m_Script: {fileID: 11500000, guid: cc1c2cc6fac734b8eac771ad4ae62c73, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   inputActionAsset: {fileID: -944628639613478452, guid: 445da62e811e3254c927570f340ea56d,
     type: 3}
-  lineColor: {r: 1, g: 0.7202714, b: 0, a: 1}
+  lineColor: {r: 1, g: 0.72156864, b: 0, a: 1}
   closedLoopLineColor: {r: 0, g: 1, b: 0, a: 1}
   lineWidthMultiplier: 1
   maxSelectionDistanceFromCamera: 10000
@@ -718,7 +718,7 @@ MonoBehaviour:
   lockInputLayers:
     serializedVersion: 2
     m_Bits: 32
-  mode: 2
+  mode: 0
   polygonLineRenderer: {fileID: 5035265957184785308}
   previewLineRenderer: {fileID: 190626057916171551}
   currentWorldCoordinate: {x: 0, y: 0, z: 0}
@@ -1152,7 +1152,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1272771895099388988}
   - component: {fileID: 5614695549320686730}
-  - component: {fileID: 7857407149832917040}
+  - component: {fileID: 6819746166564945398}
   m_Layer: 0
   m_Name: PolygonSelection_Line
   m_TagString: Untagged
@@ -1282,7 +1282,7 @@ LineRenderer:
   m_UseWorldSpace: 1
   m_Loop: 0
   m_ApplyActiveColorSpace: 0
---- !u!114 &7857407149832917040
+--- !u!114 &6819746166564945398
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1291,12 +1291,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 7239524049806933421}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0e0e5a1aab0d69a4fb6831b226ee84c7, type: 3}
+  m_Script: {fileID: 11500000, guid: cc1c2cc6fac734b8eac771ad4ae62c73, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   inputActionAsset: {fileID: -944628639613478452, guid: 445da62e811e3254c927570f340ea56d,
     type: 3}
-  lineColor: {r: 1, g: 0.7202714, b: 0, a: 1}
+  lineColor: {r: 1, g: 0.72156864, b: 0, a: 1}
   closedLoopLineColor: {r: 0, g: 1, b: 0, a: 1}
   lineWidthMultiplier: 1
   maxSelectionDistanceFromCamera: 10000

--- a/Assets/Prefabs/CustomLayers/PolygonInputToLayer.prefab
+++ b/Assets/Prefabs/CustomLayers/PolygonInputToLayer.prefab
@@ -1544,6 +1544,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   minDistance: 100
   maxDistance: 1000
+  minCamHeightMultiplier: 0.1
+  maxCamHeightMultiplier: 100
   lookDirectionResolution:
     serializedVersion: 2
     m_Curve:
@@ -1577,6 +1579,7 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+  terrainLayer: {fileID: 0}
 --- !u!20 &5783392271817491039
 Camera:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/CustomLayers/PolygonInputToLayer.prefab
+++ b/Assets/Prefabs/CustomLayers/PolygonInputToLayer.prefab
@@ -1484,6 +1484,7 @@ GameObject:
   - component: {fileID: 4912615273628568593}
   - component: {fileID: 5783392271817491039}
   - component: {fileID: 758463596900562266}
+  - component: {fileID: 3544518474178100614}
   m_Layer: 0
   m_Name: Projector
   m_TagString: Untagged
@@ -1675,3 +1676,15 @@ MonoBehaviour:
     mipBias: 0
     varianceClampScale: 0.9
     contrastAdaptiveSharpening: 0
+--- !u!114 &3544518474178100614
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8777288894377185338}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d602daece20d4d718251faaf0cb627c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/CustomLayers/PolygonInputToLayer.prefab
+++ b/Assets/Prefabs/CustomLayers/PolygonInputToLayer.prefab
@@ -1546,7 +1546,7 @@ MonoBehaviour:
   minDistance: 100
   maxDistance: 1000
   minCamHeightMultiplier: 0.1
-  maxCamHeightMultiplier: 100
+  maxCamHeightMultiplier: 50
   lookDirectionResolution:
     serializedVersion: 2
     m_Curve:

--- a/Assets/Prefabs/CustomLayers/PolygonInputToLayer.prefab
+++ b/Assets/Prefabs/CustomLayers/PolygonInputToLayer.prefab
@@ -338,6 +338,7 @@ Transform:
   m_Children:
   - {fileID: 5035265957184785311}
   - {fileID: 1272771895099388988}
+  - {fileID: 4682479123126883472}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6055517019102079451
@@ -1470,3 +1471,204 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &8777288894377185338
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4682479123126883472}
+  - component: {fileID: 2516267178798732109}
+  - component: {fileID: 4912615273628568593}
+  - component: {fileID: 5783392271817491039}
+  - component: {fileID: 758463596900562266}
+  m_Layer: 0
+  m_Name: Projector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4682479123126883472
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8777288894377185338}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8252544850299417775}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!114 &2516267178798732109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8777288894377185338}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0777d029ed3dffa4692f417d4aba19ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 2af29ec81e9884f66870fe0c48ac0943, type: 2}
+  m_DrawDistance: 1000
+  m_FadeScale: 0.9
+  m_StartAngleFade: 180
+  m_EndAngleFade: 180
+  m_UVScale: {x: 1, y: 1}
+  m_UVBias: {x: 0, y: 0}
+  m_DecalLayerMask: 1
+  m_ScaleMode: 0
+  m_Offset: {x: 0, y: 0, z: 500}
+  m_Size: {x: 1, y: 1, z: 1000}
+  m_FadeFactor: 1
+--- !u!114 &4912615273628568593
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8777288894377185338}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6145c0f4c7b374b7abe8bf0d2f19fe2b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  minDistance: 100
+  maxDistance: 1000
+  lookDirectionResolution:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 4.682676
+      outSlope: 4.682676
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0.13094941
+    - serializedVersion: 3
+      time: 0.337511
+      value: 0.83018327
+      inSlope: 0.75549847
+      outSlope: 0.75549847
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 0.033028353
+      outSlope: 0.033028353
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 1
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!20 &5783392271817491039
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8777288894377185338}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 4
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 2048
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 8400000, guid: b858922351e2e427780c2ced9f2e0a46, type: 2}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &758463596900562266
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8777288894377185338}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    quality: 3
+    frameInfluence: 0.1
+    jitterScale: 1
+    mipBias: 0
+    varianceClampScale: 0.9
+    contrastAdaptiveSharpening: 0

--- a/Assets/Prefabs/CustomLayers/PolygonInputToLayer.prefab
+++ b/Assets/Prefabs/CustomLayers/PolygonInputToLayer.prefab
@@ -162,8 +162,8 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 0.4, y: 0.4, z: 0.4}
+  m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 5805241480911030117}
   m_Father: {fileID: 1272771895099388988}
@@ -471,7 +471,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   polygonExtrusionHeight: 10
-  polygonMeshMaterial: {fileID: 2100000, guid: 44d459479e0340446b1215b3f6901764, type: 2}
+  polygonMeshMaterial: {fileID: 2100000, guid: c7fb2e346bb0d4f6da1f26f4c0bcf533, type: 2}
   polygonInput: {fileID: 2971444630074657358}
   lineInput: {fileID: 6819746166564945398}
   defaultLineWidth: 10
@@ -538,8 +538,8 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 0.4, y: 0.4, z: 0.4}
+  m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 3790482540107165208}
   m_Father: {fileID: 5035265957184785311}

--- a/Assets/Prefabs/OpticalRaycaster.prefab
+++ b/Assets/Prefabs/OpticalRaycaster.prefab
@@ -44,7 +44,7 @@ Camera:
   m_Enabled: 0
   serializedVersion: 2
   m_ClearFlags: 2
-  m_BackGroundColor: {r: 1, g: 0, b: 0, a: 1}
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -479,6 +479,11 @@ PrefabInstance:
       propertyPath: far clip plane
       value: 15000
       objectReference: {fileID: 0}
+    - target: {fileID: 1107191816428015816, guid: 8a8c1bdd94f08d144a7410a838c895ad,
+        type: 3}
+      propertyPath: m_CullingMask.m_Bits
+      value: 2039
+      objectReference: {fileID: 0}
     - target: {fileID: 1107191816428015817, guid: 8a8c1bdd94f08d144a7410a838c895ad,
         type: 3}
       propertyPath: m_RootOrder
@@ -1706,6 +1711,11 @@ PrefabInstance:
       propertyPath: targetGameObject
       value: 
       objectReference: {fileID: 767208734}
+    - target: {fileID: 6372084430124044627, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
+        type: 3}
+      propertyPath: polygonMeshMaterial
+      value: 
+      objectReference: {fileID: 2100000, guid: c7fb2e346bb0d4f6da1f26f4c0bcf533, type: 2}
     - target: {fileID: 6562649301780415454, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: onTriggered.m_PersistentCalls.m_Calls.Array.size

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 8900000, guid: ceb1e640e6a4fb7448e1c3d4c464d117, type: 3}
   m_Sun: {fileID: 1461716753}
-  m_IndirectSpecularColor: {r: 0.62148476, g: 0.697132, b: 0.8781752, a: 1}
+  m_IndirectSpecularColor: {r: 0.62166274, g: 0.696237, b: 0.8776156, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -478,6 +478,11 @@ PrefabInstance:
         type: 3}
       propertyPath: far clip plane
       value: 8000
+      objectReference: {fileID: 0}
+    - target: {fileID: 1107191816428015816, guid: 8a8c1bdd94f08d144a7410a838c895ad,
+        type: 3}
+      propertyPath: m_CullingMask.m_Bits
+      value: 2039
       objectReference: {fileID: 0}
     - target: {fileID: 1107191816428015817, guid: 8a8c1bdd94f08d144a7410a838c895ad,
         type: 3}
@@ -1721,22 +1726,22 @@ PrefabInstance:
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.00967823
+      value: 0.10793316
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.0042933556
+      value: 0.012742785
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.91404337
+      value: 0.9872201
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.40547842
+      value: -0.11655299
       objectReference: {fileID: 0}
     - target: {fileID: 3919916255551741050, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
@@ -2454,7 +2459,7 @@ PrefabInstance:
     - target: {fileID: 70272756425911697, guid: 9963fec33e379324db2affcb3f83332f,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 45.265
       objectReference: {fileID: 0}
     - target: {fileID: 70272756425911697, guid: 9963fec33e379324db2affcb3f83332f,
         type: 3}

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 8900000, guid: ceb1e640e6a4fb7448e1c3d4c464d117, type: 3}
   m_Sun: {fileID: 1461716753}
-  m_IndirectSpecularColor: {r: 0.62148476, g: 0.697132, b: 0.8781752, a: 1}
+  m_IndirectSpecularColor: {r: 0.62166274, g: 0.696237, b: 0.8776156, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1534,22 +1534,22 @@ PrefabInstance:
     - target: {fileID: 2794549335201400503, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: day
-      value: 13
+      value: 18
       objectReference: {fileID: 0}
     - target: {fileID: 2794549335201400503, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: hour
-      value: 11
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 2794549335201400503, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: month
-      value: 12
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 2794549335201400503, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: minutes
-      value: 39
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 2921212951514727232, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
@@ -1629,22 +1629,22 @@ PrefabInstance:
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.29619306
+      value: 0.58189774
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.106007256
+      value: 0.13012917
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.8937127
+      value: 0.78343284
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.31985903
+      value: -0.17519824
       objectReference: {fileID: 0}
     - target: {fileID: 3919916255551741050, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
@@ -1809,6 +1809,11 @@ PrefabInstance:
     - target: {fileID: 8708860589399019762, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: <IsReferenceLayer>k__BackingField
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8889229651641476052, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
+        type: 3}
+      propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9065098773059963892, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,

--- a/Assets/Scripts/Layers/LayerTypes/PolygonSelectionLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/PolygonSelectionLayer.cs
@@ -177,7 +177,7 @@ namespace Netherlands3D.Twin.Layers
         public static PolygonVisualisation CreatePolygonMesh(List<Vector3> polygon, float polygonExtrusionHeight, Material polygonMeshMaterial)
         {
             var contours = new List<List<Vector3>> { polygon };
-            var polygonVisualisation = PolygonVisualisationUtility.CreateAndReturnPolygonObject(contours, polygonExtrusionHeight, true, false, false, polygonMeshMaterial);
+            var polygonVisualisation = PolygonVisualisationUtility.CreateAndReturnPolygonObject(contours, polygonExtrusionHeight, false, false, false, polygonMeshMaterial);
             polygonVisualisation.DrawLine = false; //lines will be drawn per layer, but a single mesh will receive clicks to select
 
             polygonVisualisation.gameObject.layer = LayerMask.NameToLayer("ScatterPolygons");

--- a/Assets/Scripts/Layers/LayerTypes/PolygonSelectionLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/PolygonSelectionLayer.cs
@@ -18,6 +18,7 @@ namespace Netherlands3D.Twin.Layers
 
     public class PolygonSelectionLayer : LayerNL3DBase, ILayerWithProperties
     {
+        private ShapeType shapeType;
         public CompoundPolygon Polygon { get; set; }
         public PolygonVisualisation PolygonVisualisation { get; private set; }
 
@@ -27,11 +28,9 @@ namespace Netherlands3D.Twin.Layers
 
         public UnityEvent<PolygonSelectionLayer> polygonSelected = new();
         public UnityEvent polygonChanged = new();
-
-        private ShapeType shapeType;
-
+        
         private List<IPropertySectionInstantiator> propertySections = new();
-
+        
         public ShapeType ShapeType
         {
             get => shapeType;
@@ -72,6 +71,8 @@ namespace Netherlands3D.Twin.Layers
             if (shapeType == ShapeType.Line)
                 UI.ToggleProperties(true); //start with the properties section opened. this is done in Start, because we need to wait for the UI to initialize in base.Start()
         }
+
+        
         public void SelectPolygon()
         {
             if (UI)

--- a/Assets/Scripts/Layers/LayerTypes/PolygonSelectionLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/PolygonSelectionLayer.cs
@@ -180,6 +180,8 @@ namespace Netherlands3D.Twin.Layers
             var polygonVisualisation = PolygonVisualisationUtility.CreateAndReturnPolygonObject(contours, polygonExtrusionHeight, true, false, false, polygonMeshMaterial);
             polygonVisualisation.DrawLine = false; //lines will be drawn per layer, but a single mesh will receive clicks to select
 
+            polygonVisualisation.gameObject.layer = LayerMask.NameToLayer("ScatterPolygons");
+            
             return polygonVisualisation;
         }
 

--- a/Assets/Scripts/Layers/LayerTypes/PolygonSelectionLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/PolygonSelectionLayer.cs
@@ -62,27 +62,17 @@ namespace Netherlands3D.Twin.Layers
                 SetLine(polygon);
             else
                 SetPolygon(polygon);
-            PolygonVisualisation.reselectVisualisedPolygon.AddListener(OnPolygonVisualisationSelected);
+
+            PolygonSelectionCalculator.RegisterPolygon(this);
         }
 
         protected override void Start()
         {
             base.Start();
-            if(shapeType == ShapeType.Line)
+            if (shapeType == ShapeType.Line)
                 UI.ToggleProperties(true); //start with the properties section opened. this is done in Start, because we need to wait for the UI to initialize in base.Start()
         }
-
-        private void OnEnable()
-        {
-            ClickNothingPlane.ClickedOnNothing.AddListener(DeselectPolygon);
-        }
-
-        private void OnDisable()
-        {
-            ClickNothingPlane.ClickedOnNothing.RemoveListener(DeselectPolygon);
-        }
-
-        private void OnPolygonVisualisationSelected(PolygonVisualisation visualisation)
+        public void SelectPolygon()
         {
             if (UI)
                 UI.Select(!LayerUI.SequentialSelectionModifierKeyIsPressed() && !LayerUI.AddToSelectionModifierKeyIsPressed()); //if there is no UI, this will do nothing. this is intended as when the layer panel is closed the polygon should not be (accidentally) selectable
@@ -181,7 +171,7 @@ namespace Netherlands3D.Twin.Layers
             polygonVisualisation.DrawLine = false; //lines will be drawn per layer, but a single mesh will receive clicks to select
 
             polygonVisualisation.gameObject.layer = LayerMask.NameToLayer("ScatterPolygons");
-            
+
             return polygonVisualisation;
         }
 
@@ -206,7 +196,7 @@ namespace Netherlands3D.Twin.Layers
         protected override void OnDestroy()
         {
             base.OnDestroy();
-            PolygonVisualisation.reselectVisualisedPolygon.RemoveListener(OnPolygonVisualisationSelected);
+            PolygonSelectionCalculator.UnregisterPolygon(this);
             Destroy(PolygonVisualisation.gameObject);
         }
 

--- a/Assets/Scripts/Layers/PolygonDecalProjector.cs
+++ b/Assets/Scripts/Layers/PolygonDecalProjector.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering.Universal;
+
+namespace Netherlands3D.Twin
+{
+    public class PolygonDecalProjector : MonoBehaviour
+    {
+        [Header("Mask camera settings")]
+        [SerializeField] private float minDistance = 100;
+        [SerializeField] private float maxDistance = 1000;
+        
+        [Header("Mask texture settings")]
+        [SerializeField] private AnimationCurve lookDirectionResolution;
+        
+        private DecalProjector decalProjector;
+        private Camera projectionCamera;
+        private OpticalRaycaster opticalRaycaster;
+
+        private void Awake()
+        {
+            decalProjector = GetComponent<DecalProjector>();
+            projectionCamera = GetComponent<Camera>();
+            opticalRaycaster = FindAnyObjectByType<OpticalRaycaster>();
+            // renderTexture = new RenderTexture(1024, 1024, 24);
+        }
+
+        private void Update()
+        {
+            var lookingForward = 1-Math.Abs(Vector3.Dot(Vector3.down, Camera.main.transform.forward)); //0 is looking top down, 1 is looking straight to the horizon
+            var sampleMaxDistance = Mathf.Lerp(maxDistance, minDistance, lookDirectionResolution.Evaluate(lookingForward));
+            print("sample: "+sampleMaxDistance);
+
+            var minCamHeight = -20f;
+            var maxCamHeight = 500f;
+            var camHeight = Camera.main.transform.position.y; //todo: get real height above terrain: get bounds of all terrein, get terrain with smallest y extents. use this bounds center as an estimation
+            var normalizedHeight = Mathf.InverseLerp(minCamHeight, maxCamHeight, camHeight);
+            var camHeigtMultiplier = Mathf.Lerp(1, 50, normalizedHeight);
+            sampleMaxDistance *= camHeigtMultiplier;
+            // print("sample wit height: "+sampleMaxDistance);
+
+            var extent = Camera.main.GetExtent(sampleMaxDistance);
+            var w = (float)extent.Width;
+            var h = (float)extent.Height;
+            var maxDimension = Mathf.Max(w,h);
+
+            var pos = new Vector3((float)extent.CenterX, 500, (float)extent.CenterY);
+            var size = new Vector3(maxDimension, maxDimension, decalProjector.size.z);
+
+            decalProjector.transform.position = pos;
+            decalProjector.size = size;
+            
+            projectionCamera.orthographicSize = maxDimension / 2;
+        }
+    }
+}

--- a/Assets/Scripts/Layers/PolygonDecalProjector.cs
+++ b/Assets/Scripts/Layers/PolygonDecalProjector.cs
@@ -10,6 +10,9 @@ namespace Netherlands3D.Twin
         [Header("Mask camera settings")]
         [SerializeField] private float minDistance = 100;
         [SerializeField] private float maxDistance = 1000;
+
+        [SerializeField] private float minCamHeightMultiplier = 0.1f;
+        [SerializeField] private float maxCamHeightMultiplier = 100f;
         
         [Header("Mask texture settings")]
         [SerializeField] private AnimationCurve lookDirectionResolution;
@@ -28,15 +31,15 @@ namespace Netherlands3D.Twin
         {
             var lookingForward = 1-Math.Abs(Vector3.Dot(Vector3.down, Camera.main.transform.forward)); //0 is looking top down, 1 is looking straight to the horizon
             var sampleMaxDistance = Mathf.Lerp(maxDistance, minDistance, lookDirectionResolution.Evaluate(lookingForward));
-            print("sample: "+sampleMaxDistance);
 
-            var minCamHeight = -20f;
-            var maxCamHeight = 500f;
+            var minCamHeight = -50f;
+            var maxCamHeight = 1500f;
             var camHeight = EstimateCameraHeight(); 
             var normalizedHeight = Mathf.InverseLerp(minCamHeight, maxCamHeight, camHeight);
-            var camHeigtMultiplier = Mathf.Lerp(0.5f, 50f, normalizedHeight);
-            sampleMaxDistance *= camHeigtMultiplier;
-
+            var t = lookDirectionResolution.Evaluate(normalizedHeight);
+            var camHeightMultiplier = Mathf.Lerp(minCamHeightMultiplier, maxCamHeightMultiplier, normalizedHeight);
+            sampleMaxDistance *= camHeightMultiplier;
+            
             var extent = Camera.main.GetExtent(sampleMaxDistance);
             var w = (float)extent.Width;
             var h = (float)extent.Height;

--- a/Assets/Scripts/Layers/PolygonDecalProjector.cs.meta
+++ b/Assets/Scripts/Layers/PolygonDecalProjector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6145c0f4c7b374b7abe8bf0d2f19fe2b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Layers/PolygonSelectionCalculator.cs
+++ b/Assets/Scripts/Layers/PolygonSelectionCalculator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Netherlands3D.Twin.Layers;
+using Netherlands3D.Twin.UI.LayerInspector;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
@@ -28,7 +29,7 @@ namespace Netherlands3D.Twin
         {
             ClickNothingPlane.ClickedOnNothing.AddListener(ProcessClick);
         }
-        
+
         private void OnDisable()
         {
             ClickNothingPlane.ClickedOnNothing.RemoveListener(ProcessClick);
@@ -65,8 +66,10 @@ namespace Netherlands3D.Twin
                     layer.SelectPolygon();
                     return; //select only one
                 }
-
-                layer.DeselectPolygon(); //deselect if the click wasn't in the polygon
+                else
+                {
+                    layer.DeselectPolygon(); //deselect if the click wasn't in the polygon and the multiselect modifier keys aren't pressed
+                }
             }
         }
 

--- a/Assets/Scripts/Layers/PolygonSelectionCalculator.cs
+++ b/Assets/Scripts/Layers/PolygonSelectionCalculator.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Netherlands3D.Twin.Layers;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
+
+namespace Netherlands3D.Twin
+{
+    public class PolygonSelectionCalculator : MonoBehaviour
+    {
+        public static List<PolygonSelectionLayer> Layers = new();
+        private OpticalRaycaster opticalRaycaster;
+
+        public static void RegisterPolygon(PolygonSelectionLayer layer)
+        {
+            if (Layers.Contains(layer))
+            {
+                Debug.LogError("layer " + layer + " is already registered", layer);
+                return;
+            }
+
+            Layers.Add(layer);
+        }
+
+        private void OnEnable()
+        {
+            ClickNothingPlane.ClickedOnNothing.AddListener(ProcessClick);
+        }
+        
+        private void OnDisable()
+        {
+            ClickNothingPlane.ClickedOnNothing.RemoveListener(ProcessClick);
+        }
+
+
+        public static void UnregisterPolygon(PolygonSelectionLayer layer)
+        {
+            if (!Layers.Contains(layer))
+            {
+                Debug.LogError("layer " + layer + " is not registered", layer);
+                return;
+            }
+
+            Layers.Remove(layer);
+        }
+
+        private void Awake()
+        {
+            opticalRaycaster = FindAnyObjectByType<OpticalRaycaster>();
+        }
+
+        private void ProcessClick()
+        {
+            var camera = Camera.main;
+            Plane[] frustumPlanes = GeometryUtility.CalculateFrustumPlanes(camera);
+            var worldPoint = opticalRaycaster.GetWorldPointAtCameraScreenPoint(camera, Pointer.current.position.ReadValue());
+
+            foreach (var layer in Layers)
+            {
+                bool wasSelected = ProcessPolygonSelection(layer, camera, frustumPlanes, worldPoint);
+                if (wasSelected)
+                {
+                    layer.SelectPolygon();
+                    return; //select only one
+                }
+
+                layer.DeselectPolygon(); //deselect if the click wasn't in the polygon
+            }
+        }
+
+        private bool ProcessPolygonSelection(PolygonSelectionLayer layer, Camera camera, Plane[] frustumPlanes, Vector3 worldPoint)
+        {
+            //since we use a visual projection of the polygon, we need to calculate if a user clicks on the polygon manually
+            //if this polygon is out of view of the camera, it can't be clicked on.
+            var bounds = layer.Polygon.Bounds;
+            if (!IsBoundsInView(bounds, frustumPlanes))
+                return false;
+
+            //if the click is outside of the polygon bounds, this polygon wasn't selected
+            var point2d = new Vector2(worldPoint.x, worldPoint.z);
+            if (!IsInBounds2D(bounds, point2d))
+                return false;
+
+            //check if the click was in the polygon bounds
+            return CompoundPolygon.IsPointInPolygon(point2d, layer.Polygon);
+        }
+
+        public static bool IsBoundsInView(Bounds bounds, Plane[] frustumPlanes)
+        {
+            return GeometryUtility.TestPlanesAABB(frustumPlanes, bounds);
+        }
+
+        public static bool IsInBounds2D(Bounds bounds, Vector2 point)
+        {
+            return point.x > bounds.min.x && point.x < bounds.max.x && point.y > bounds.min.z && point.y < bounds.max.z;
+        }
+    }
+}

--- a/Assets/Scripts/Layers/PolygonSelectionCalculator.cs.meta
+++ b/Assets/Scripts/Layers/PolygonSelectionCalculator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d602daece20d4d718251faaf0cb627c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Samplers/ScatterMap.cs
+++ b/Assets/Scripts/Samplers/ScatterMap.cs
@@ -241,8 +241,8 @@ namespace Netherlands3D.Twin
                 offsetPoint.y = newColorSample.b;
                 offsetPoint.z = rotatedY + boundsCenter2D.y;
 
-                sampledRandomness.x = newColorSample.r; //for our purposes, it doesn't really matter if these use the same sampled values as for the random offset
-                sampledRandomness.y = newColorSample.g;
+                sampledRandomness.x = colorSample.r; //for our purposes, it doesn't really matter if these use the same sampled values as for the random offset
+                sampledRandomness.y = colorSample.g;
 
                 points.Add(offsetPoint);
                 sampledScales.Add(sampledRandomness);

--- a/Assets/Scripts/Selection/PolygonInputWithOpticalRaycastHeight.cs
+++ b/Assets/Scripts/Selection/PolygonInputWithOpticalRaycastHeight.cs
@@ -14,12 +14,17 @@ namespace Netherlands3D.Twin
             base.Awake();
             opticalRaycaster = GameObject.FindAnyObjectByType<OpticalRaycaster>();
         }
-        
+
         protected override void UpdateCurrentWorldCoordinate()
         {
             var currentPointerPosition = pointerAction.ReadValue<Vector2>();
             var point = opticalRaycaster.GetWorldPointAtCameraScreenPoint(Camera.main, currentPointerPosition);
-            currentWorldCoordinate = point;
+
+            print(point);
+            if (point != Vector3.right) //todo: why is the default value (1,0,0) instead of (0,0,0)?
+                currentWorldCoordinate = point;
+            else
+                base.UpdateCurrentWorldCoordinate();
         }
     }
 }

--- a/Assets/Scripts/Selection/PolygonInputWithOpticalRaycastHeight.cs
+++ b/Assets/Scripts/Selection/PolygonInputWithOpticalRaycastHeight.cs
@@ -20,7 +20,6 @@ namespace Netherlands3D.Twin
             var currentPointerPosition = pointerAction.ReadValue<Vector2>();
             var point = opticalRaycaster.GetWorldPointAtCameraScreenPoint(Camera.main, currentPointerPosition);
 
-            print(point);
             if (point != Vector3.right) //todo: why is the default value (1,0,0) instead of (0,0,0)?
                 currentWorldCoordinate = point;
             else

--- a/Assets/Scripts/Selection/PolygonInputWithOpticalRaycastHeight.cs
+++ b/Assets/Scripts/Selection/PolygonInputWithOpticalRaycastHeight.cs
@@ -20,7 +20,7 @@ namespace Netherlands3D.Twin
             var currentPointerPosition = pointerAction.ReadValue<Vector2>();
             var point = opticalRaycaster.GetWorldPointAtCameraScreenPoint(Camera.main, currentPointerPosition);
 
-            if (point != Vector3.right) //todo: why is the default value (1,0,0) instead of (0,0,0)?
+            if (point != Vector3.zero)
                 currentWorldCoordinate = point;
             else
                 base.UpdateCurrentWorldCoordinate();

--- a/Assets/Scripts/Selection/PolygonInputWithOpticalRaycastHeight.cs
+++ b/Assets/Scripts/Selection/PolygonInputWithOpticalRaycastHeight.cs
@@ -1,0 +1,25 @@
+using System;
+using UnityEngine;
+using Netherlands3D.SelectionTools;
+using UnityEngine.InputSystem;
+
+namespace Netherlands3D.Twin
+{
+    public class PolygonInputWithOpticalRaycastHeight : PolygonInput
+    {
+        private OpticalRaycaster opticalRaycaster;
+
+        protected override void Awake()
+        {
+            base.Awake();
+            opticalRaycaster = GameObject.FindAnyObjectByType<OpticalRaycaster>();
+        }
+        
+        protected override void UpdateCurrentWorldCoordinate()
+        {
+            var currentPointerPosition = pointerAction.ReadValue<Vector2>();
+            var point = opticalRaycaster.GetWorldPointAtCameraScreenPoint(Camera.main, currentPointerPosition);
+            currentWorldCoordinate = point;
+        }
+    }
+}

--- a/Assets/Scripts/Selection/PolygonInputWithOpticalRaycastHeight.cs.meta
+++ b/Assets/Scripts/Selection/PolygonInputWithOpticalRaycastHeight.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc1c2cc6fac734b8eac771ad4ae62c73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility.meta
+++ b/Assets/Scripts/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2636e2a57eb204531a9b755c6cfd465a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/CameraExtentions.cs
+++ b/Assets/Scripts/Utility/CameraExtentions.cs
@@ -1,0 +1,192 @@
+using System;
+using UnityEngine;
+using Netherlands3D.Coordinates;
+
+namespace Netherlands3D.Twin
+{
+    
+    public struct Extent
+    {
+        private readonly double _minX;
+        private readonly double _minY;
+        private readonly double _maxX;
+        private readonly double _maxY;
+
+        public Extent(double minX, double minY, double maxX, double maxY) : this()
+        {
+            _minX = minX;
+            _minY = minY;
+            _maxX = maxX;
+            _maxY = maxY;
+
+            if (minX > maxX || minY > maxY)
+            {
+                throw new ArgumentException("min should be smaller than max");
+            }
+        }
+
+        public double MinX
+        {
+            get { return _minX; }
+        }
+
+        public double MinY
+        {
+            get { return _minY; }
+        }
+
+        public double MaxX
+        {
+            get { return _maxX; }
+        }
+
+        public double MaxY
+        {
+            get { return _maxY; }
+        }
+
+        public double CenterX => (MinX + MaxX) / 2.0;
+        public double CenterY => (MinY + MaxY) / 2.0;
+        public double Width => MaxX - MinX;
+        public double Height => MaxY - MinY;
+        public double Area => Width * Height;
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Extent extent))
+                return false;
+
+            return this.CenterX == extent.CenterX && this.MinX == extent.MinX && this.MinY == extent.MinY && this.MaxX == extent.MaxX && this.MaxY == extent.MaxY;
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+    }
+
+
+
+    
+    public static class CameraExtensions
+    {
+        public static Vector3[] corners = new Vector3[4];
+
+        private static Vector3 unityMin;
+        private static Vector3 unityMax;
+
+        private static Vector2 topLeft = new Vector2(0, 1);
+        private static Vector2 topRight = new Vector2(1, 1);
+        private static Vector2 bottomRight = new Vector2(1, 0);
+        private static Vector2 bottomLeft = new Vector2(0, 0);
+
+        private static Plane[] cameraFrustumPlanes = new Plane[6]
+        {
+            new Plane(), //Left
+            new Plane(), //Right
+            new Plane(), //Down
+            new Plane(), //Up
+            new Plane(), //Near
+            new Plane(), //Far
+        };
+
+        public static Extent GetExtent(this Camera camera, float maximumViewDistance = 0)
+        {
+            if (maximumViewDistance == 0) maximumViewDistance = camera.farClipPlane;
+            CalculateCornerExtents(camera, maximumViewDistance);
+
+            // Area that should be loaded
+            var extent = new Extent(unityMin.x, unityMin.z, unityMax.x, unityMax.z);
+
+            return extent;
+        }
+
+        public static Extent GetRDExtent(this Camera camera, float maximumViewDistance = 0)
+        {
+            if (maximumViewDistance == 0) maximumViewDistance = camera.farClipPlane;
+            CalculateCornerExtents(camera, maximumViewDistance);
+
+            // Convert min and max to WGS84 coordinates
+            var rdMin = CoordinateConverter.UnitytoRD(unityMin);
+            var rdMax = CoordinateConverter.UnitytoRD(unityMax);
+
+            // Area that should be loaded
+            var extent = new Extent(rdMin.x, rdMin.y, rdMax.x, rdMax.y);
+
+            return extent;
+        }
+
+        private static void CalculateCornerExtents(Camera camera, float maximumViewDistance)
+        {
+            // Determine what world coordinates are in the corners of our view
+            corners[0] = GetCornerPoint(camera, topLeft, maximumViewDistance);
+            corners[1] = GetCornerPoint(camera, topRight, maximumViewDistance);
+            corners[2] = GetCornerPoint(camera, bottomRight, maximumViewDistance);
+            corners[3] = GetCornerPoint(camera, bottomLeft, maximumViewDistance);
+
+            // Determine the min and max X- en Z-value of the visible coordinates
+            unityMax = new Vector3(-float.MaxValue, -float.MaxValue, -float.MaxValue);
+            unityMin = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
+            for (int i = 0; i < 4; i++)
+            {
+                unityMin.x = Mathf.Min(unityMin.x, corners[i].x);
+                unityMin.z = Mathf.Min(unityMin.z, corners[i].z);
+                unityMax.x = Mathf.Max(unityMax.x, corners[i].x);
+                unityMax.z = Mathf.Max(unityMax.z, corners[i].z);
+            }
+        }
+
+        private static Vector3 GetCornerPoint(this Camera camera, Vector2 screenPosition, float maximumViewDistance)
+        {
+            var output = new Vector3();
+
+            var topScreenPointFar = Camera.main.ViewportToWorldPoint(new Vector3(screenPosition.x, screenPosition.y, 10000));
+            var topScreenPointNear = Camera.main.ViewportToWorldPoint(new Vector3(screenPosition.x, screenPosition.y, 10));
+
+            // Calculate direction vector
+            Vector3 direction = topScreenPointNear - topScreenPointFar;
+            float factor; //factor waarmee de Richtingvector vermenigvuldigd moet worden om op het maaiveld te stoppen
+            if (direction.y < 0) //wanneer de Richtingvector omhooggaat deze factor op 1 instellen
+            {
+                factor = 1;
+            }
+            else
+            {
+                factor = ((topScreenPointNear.y) / direction.y); //factor bepalen t.o.v. maaiveld (aanname maaiveld op 0 NAP = ca 40 Unityeenheden in Y-richting)
+            }
+
+            // Determine the X, Y, en Z location where the viewline ends
+            output.x = topScreenPointNear.x - Mathf.Clamp((factor * direction.x), -1 * maximumViewDistance, maximumViewDistance);
+            output.y = topScreenPointNear.y - Mathf.Clamp((factor * direction.y), -1 * maximumViewDistance, maximumViewDistance);
+            output.z = topScreenPointNear.z - Mathf.Clamp((factor * direction.z), -1 * maximumViewDistance, maximumViewDistance);
+
+            return output;
+        }
+
+        public static Vector3[] GetWorldSpaceCorners(this Camera camera)
+        {
+            return corners;
+        }
+
+        /// <summary>
+        /// Get the position of a screen point in world coordinates ( on a plane )
+        /// </summary>
+        /// <param name="screenPoint">The point in screenpoint coordinates</param>
+        /// <returns></returns>
+        public static Vector3 GetCoordinateInWorld(this Camera camera, Vector3 screenPoint, Plane worldPlane, float maxSelectionDistanceFromCamera = Mathf.Infinity)
+        {
+            var screenRay = camera.ScreenPointToRay(screenPoint);
+
+            worldPlane.Raycast(screenRay, out float distance);
+            var samplePoint = screenRay.GetPoint(Mathf.Min(maxSelectionDistanceFromCamera, distance));
+
+            return samplePoint;
+        }
+
+        public static bool InView(this Camera camera, Bounds bounds)
+        {
+            GeometryUtility.CalculateFrustumPlanes(camera, cameraFrustumPlanes);
+            return GeometryUtility.TestPlanesAABB(cameraFrustumPlanes, bounds);
+        }
+    }
+}

--- a/Assets/Scripts/Utility/CameraExtentions.cs.meta
+++ b/Assets/Scripts/Utility/CameraExtentions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12c3d25e73fd24c20a14df2a43c7da0d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Textures/PolygonProjection.renderTexture
+++ b/Assets/Textures/PolygonProjection.renderTexture
@@ -1,0 +1,40 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!84 &8400000
+RenderTexture:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PolygonProjection
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_ForcedFallbackFormat: 4
+  m_DownscaleFallback: 0
+  m_IsAlphaChannelOptional: 0
+  serializedVersion: 5
+  m_Width: 2048
+  m_Height: 2048
+  m_AntiAliasing: 1
+  m_MipCount: -1
+  m_DepthStencilFormat: 94
+  m_ColorFormat: 8
+  m_MipMap: 0
+  m_GenerateMips: 1
+  m_SRGB: 0
+  m_UseDynamicScale: 1
+  m_BindMS: 0
+  m_EnableCompatibleFormat: 1
+  m_EnableRandomWrite: 0
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 0
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 2
+  m_VolumeDepth: 1
+  m_ShadowSamplingMode: 2

--- a/Assets/Textures/PolygonProjection.renderTexture.meta
+++ b/Assets/Textures/PolygonProjection.renderTexture.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b858922351e2e427780c2ced9f2e0a46
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 8400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -20,7 +20,7 @@
     "eu.netherlands3d.meshclipper": "https://github.com/Netherlands3D/MeshClipper.git",
     "eu.netherlands3d.minimap": "1.1.4",
     "eu.netherlands3d.obj-importer": "1.0.0",
-    "eu.netherlands3d.selection-tools": "2.2.4",
+    "eu.netherlands3d.selection-tools": "2.3.0",
     "eu.netherlands3d.subobjects": "1.3.0",
     "eu.netherlands3d.tiles3d": "1.2.3",
     "eu.netherlands3d.transform-handles": "1.1.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -329,7 +329,7 @@
       "url": "https://package.openupm.com"
     },
     "eu.netherlands3d.selection-tools": {
-      "version": "2.2.4",
+      "version": "2.3.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -39,7 +39,7 @@ GraphicsSettings:
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}
-  m_CustomRenderPipeline: {fileID: 11400000, guid: fca12c78a71cf7847b29dcb830e8c2e2,
+  m_CustomRenderPipeline: {fileID: 11400000, guid: 29cbe7fa0ca3eb9428ef4851d9f9e11e,
     type: 2}
   m_TransparencySortMode: 0
   m_TransparencySortAxis: {x: 0, y: 0, z: 1}


### PR DESCRIPTION
- Added support for terrain height when drawing polygon.
- Polygons are now projected on the terrain using a decal projector (1 decal projector for all polygons to minimize performance impact)
- A balance is made for decal edge sharpness to maximize the resolution but as a tradeoff lower draw distance

test build:
https://cdn-dev-ams-3da.azureedge.net/autobuild/feature/polygon-height/1435248901/