### PR TITLE
restore AA on camera that was lost

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -609,6 +609,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1107191816428015818, guid: 8a8c1bdd94f08d144a7410a838c895ad,
         type: 3}
+      propertyPath: m_Antialiasing
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1107191816428015818, guid: 8a8c1bdd94f08d144a7410a838c895ad,
+        type: 3}
       propertyPath: m_RenderPostProcessing
       value: 1
       objectReference: {fileID: 0}

--- a/Assets/Scripts/Quality/QualitySettings.cs
+++ b/Assets/Scripts/Quality/QualitySettings.cs
@@ -14,6 +14,7 @@ namespace Netherlands3D.Twin
         void Awake()
         {
             activeRenderPipelineAsset = (UniversalRenderPipelineAsset)GraphicsSettings.currentRenderPipeline;
+            SetQualityLevel(2);
         }
 
         /// <summary>


### PR DESCRIPTION
- restore AA on camera that was lost after merge conflicts in main were solved
- set quality high at startup to make sure camera AA is enabled, even if main scene is overwritten