### PR TITLE
Enable Google 3D Tiles, and update to latest version of 3D Tiles pack…

### DIFF
--- a/Assets/Prefabs/3DTiles/RealityMesh (3D Tiles).prefab
+++ b/Assets/Prefabs/3DTiles/RealityMesh (3D Tiles).prefab
@@ -113,8 +113,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   tilesetUrl: https://tile.googleapis.com/v1/3dtiles/root.json
-  publicKey: 
-  personalKey: 
+  publicKey: AIzaSyDSu1PKgDDRC0mz4cm93Mt9834jXmoQbS0
+  personalKey: AIzaSyDSu1PKgDDRC0mz4cm93Mt9834jXmoQbS0
   root:
     isLoading: 0
     level: 0

--- a/Assets/Prefabs/3DTiles/RealityMesh (3D Tiles).prefab
+++ b/Assets/Prefabs/3DTiles/RealityMesh (3D Tiles).prefab
@@ -13,6 +13,8 @@ GameObject:
   - component: {fileID: 5648866956155822156}
   - component: {fileID: 7109194962515795805}
   - component: {fileID: 4142489338678956943}
+  - component: {fileID: -5688274655914667246}
+  - component: {fileID: -3892557586120215936}
   m_Layer: 6
   m_Name: RealityMesh (3D Tiles)
   m_TagString: Untagged
@@ -271,3 +273,36 @@ MonoBehaviour:
   UnsupportedExtensionsMessage:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &-5688274655914667246
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7974831043381414785}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 630f741154ed48488dc6602ef25dab3a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  origin: {fileID: 0}
+  worldTransformShifter: {fileID: 0}
+  referenceCoordinateSystem: 4326
+  onPreShift:
+    m_PersistentCalls:
+      m_Calls: []
+  onPostShift:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &-3892557586120215936
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7974831043381414785}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89676a9f69324d308c537c8970b47571, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scriptables/Configuration.asset
+++ b/Assets/Scriptables/Configuration.asset
@@ -29,6 +29,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 462e8813cb03c5b40bc80604c74ac17e, type: 2}
   - {fileID: 11400000, guid: 3da8bf8309a3baa4da8b4dba6d2283d9, type: 2}
   - {fileID: 11400000, guid: d06ed7bd107a54d9698c5b95998572bb, type: 2}
+  - {fileID: 11400000, guid: db8c80d7396a1c04fa85faf2b38afc2f, type: 2}
   OnAllowUserSettingsChanged:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Scripts/FloatingOrigin/ThreeDTilesWorldTransformShifter.cs
+++ b/Assets/Scripts/FloatingOrigin/ThreeDTilesWorldTransformShifter.cs
@@ -8,6 +8,11 @@ namespace Netherlands3D.Twin.FloatingOrigin
     public class ThreeDTilesWorldTransformShifter : WorldTransformShifter
     {
         private Dictionary<Transform, Coordinate> tilesToShift = new();
+        private Read3DTileset tilesetReader;
+
+        private void Awake() {
+            tilesetReader = GetComponent<Read3DTileset>();
+        }
 
         /// <summary>
         /// Because the 3D Tile handler dynamically creates and destroys tiles, we need to collect a list of transforms
@@ -52,6 +57,9 @@ namespace Netherlands3D.Twin.FloatingOrigin
 #endif
                 tile.Key.position = newPosition;
             }
+
+            //Refresh 3D Tiles internal Bounds calculations
+            tilesetReader.RecalculateBounds();
         }
     }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -22,7 +22,7 @@
     "eu.netherlands3d.obj-importer": "1.0.0",
     "eu.netherlands3d.selection-tools": "2.3.0",
     "eu.netherlands3d.subobjects": "1.3.0",
-    "eu.netherlands3d.tiles3d": "1.4.0",
+    "eu.netherlands3d.tiles3d": "1.4.1",
     "eu.netherlands3d.transform-handles": "1.1.2",
     "eu.netherlands3d.web-cursors": "2.0.0",
     "eu.netherlands3d.webgl-copy-paste": "1.1.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -375,7 +375,7 @@
       "dependencies": {}
     },
     "eu.netherlands3d.tiles3d": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -41,6 +41,7 @@ GraphicsSettings:
   - {fileID: -6465566751694194690, guid: a9c0c09940ee94ca18a37ebcd59ecca9, type: 3}
   - {fileID: -6465566751694194690, guid: 3b5ad576a7d85d745bb1094377662046, type: 3}
   - {fileID: -6465566751694194690, guid: c43d943999b82fb4a9b29c6e62a2c801, type: 3}
+  - {fileID: -6465566751694194690, guid: c87047c884d9843f5b0f4cce282aa760, type: 3}
   m_PreloadedShaders: []
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,


### PR DESCRIPTION
- Enable Google 3D Tiles, and update to latest version of 3D Tiles package that removes the validation on the tileset.json because google uses root.json
- RecalculateBounds of Read3DTileset on Origin shift (fixing issues with 3D tile layers after origin shifts)
- Always include gltf 'Unlit' shader in Graphic Settings (used by Google Reality Mesh gltfs)