### PR TITLE
Bugfix/coordinate selection screen

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -12,7 +12,7 @@
     "com.unity.textmeshpro": "3.2.0-pre.6",
     "com.unity.timeline": "1.7.6",
     "com.unity.ugui": "1.0.0",
-    "eu.netherlands3d.address-search": "1.1.3",
+    "eu.netherlands3d.address-search": "https://github.com/Netherlands3D/AddressSearch.git",
     "eu.netherlands3d.cartesiantiles": "1.1.2",
     "eu.netherlands3d.collada": "0.1.1",
     "eu.netherlands3d.coordinates": "1.6.2",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -12,7 +12,7 @@
     "com.unity.textmeshpro": "3.2.0-pre.6",
     "com.unity.timeline": "1.7.6",
     "com.unity.ugui": "1.0.0",
-    "eu.netherlands3d.address-search": "https://github.com/Netherlands3D/AddressSearch.git",
+    "eu.netherlands3d.address-search": "2.0.0",
     "eu.netherlands3d.cartesiantiles": "1.1.2",
     "eu.netherlands3d.collada": "0.1.1",
     "eu.netherlands3d.coordinates": "1.6.2",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -15,7 +15,7 @@
     "eu.netherlands3d.address-search": "1.1.3",
     "eu.netherlands3d.cartesiantiles": "1.1.2",
     "eu.netherlands3d.collada": "0.1.1",
-    "eu.netherlands3d.coordinates": "1.5.0",
+    "eu.netherlands3d.coordinates": "1.6.2",
     "eu.netherlands3d.filebrowser": "2.0.1",
     "eu.netherlands3d.masking": "2.0.1",
     "eu.netherlands3d.meshclipper": "https://github.com/Netherlands3D/MeshClipper.git",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -32,7 +32,7 @@
       "dependencies": {}
     },
     "com.unity.burst": {
-      "version": "1.8.11",
+      "version": "1.8.9",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -124,16 +124,7 @@
         "com.unity.mathematics": "1.2.1",
         "com.unity.burst": "1.8.9",
         "com.unity.render-pipelines.core": "14.0.9",
-        "com.unity.shadergraph": "14.0.9",
-        "com.unity.render-pipelines.universal-config": "14.0.9"
-      }
-    },
-    "com.unity.render-pipelines.universal-config": {
-      "version": "14.0.9",
-      "depth": 1,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.render-pipelines.core": "14.0.9"
+        "com.unity.shadergraph": "14.0.9"
       }
     },
     "com.unity.searcher": {
@@ -203,11 +194,13 @@
       "url": "https://package.openupm.com"
     },
     "eu.netherlands3d.address-search": {
-      "version": "1.1.3",
+      "version": "https://github.com/Netherlands3D/AddressSearch.git",
       "depth": 0,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://package.openupm.com"
+      "source": "git",
+      "dependencies": {
+        "eu.netherlands3d.coordinates": "1.6.2"
+      },
+      "hash": "a9b95c6452fb2d34df43aa56c34ea0d6331658cc"
     },
     "eu.netherlands3d.cartesiantiles": {
       "version": "1.1.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -194,13 +194,13 @@
       "url": "https://package.openupm.com"
     },
     "eu.netherlands3d.address-search": {
-      "version": "https://github.com/Netherlands3D/AddressSearch.git",
+      "version": "2.0.0",
       "depth": 0,
-      "source": "git",
+      "source": "registry",
       "dependencies": {
         "eu.netherlands3d.coordinates": "1.6.2"
       },
-      "hash": "a9b95c6452fb2d34df43aa56c34ea0d6331658cc"
+      "url": "https://package.openupm.com"
     },
     "eu.netherlands3d.cartesiantiles": {
       "version": "1.1.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -229,7 +229,7 @@
       "url": "https://package.openupm.com"
     },
     "eu.netherlands3d.coordinates": {
-      "version": "1.5.0",
+      "version": "1.6.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {},


### PR DESCRIPTION
- update AdressSearch package to version 2.0.0 that uses a swapped lan,lon input for the WGS84 conversion method, fixing issues with applying coordinates found after address was searched