### PR TITLE
Fixed scatter tool edge mode not working correctly

### DIFF
--- a/Assets/Scripts/Layers/LayerTypes/PolygonSelectionLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/PolygonSelectionLayer.cs
@@ -218,7 +218,7 @@ namespace Netherlands3D.Twin.Layers
 
             //Add the polygon shifter to the polygon visualisation, so it can move with our origin shifts
             polygonVisualisation.DrawLine = false; //lines will be drawn per layer, but a single mesh will receive clicks to select
-            polygonVisualisation.gameObject.layer = LayerMask.NameToLayer("ScatterPolygons");
+            polygonVisualisation.gameObject.layer = LayerMask.NameToLayer("Projected");
 
             return polygonVisualisation;
         }


### PR DESCRIPTION
Changed the (unity) layer of a PolygonVisualisationLayer so that it no longer interferes with the ScatterProjector.

https://cdn-dev-ams-3da.azureedge.net/autobuild/fix/scatter-tool-fix/1894981060/