### PR TITLE
Bugfix/geojson file import ams files

### DIFF
--- a/Assets/Scripts/Layers/Adapters/ChainOfResponsibility.cs
+++ b/Assets/Scripts/Layers/Adapters/ChainOfResponsibility.cs
@@ -76,8 +76,8 @@ namespace Netherlands3D.Twin
         private IEnumerator DownloadDataToLocalCache(LocalFile urlAndData)
         {
             var url = urlAndData.SourceUrl;
-            var optionalExtention = Path.GetExtension(url);
             var uwr = UnityWebRequest.Get(url);
+            var optionalExtention = Path.GetExtension(url).Split("?")[0];
             var guidFilename = Guid.NewGuid().ToString() + optionalExtention;
             string path = Path.Combine(Application.persistentDataPath, guidFilename);
 

--- a/Assets/Scripts/Layers/LayerTypes/GeoJSONLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/GeoJSONLayer.cs
@@ -311,6 +311,9 @@ namespace Netherlands3D.Twin.Layers
             bool crsFound = false;
             do //process the found object, and continue reading after processing is done
             {
+                // Log the current token
+                Debug.Log("Token: " + reader.TokenType + " Value: " + reader.Value);
+
                 if (!IsAtTypeToken(reader) && !IsAtCRSToken(reader))
                 {
                     reader.Skip(); //if the found token is is not "type" or "crs", skip this object
@@ -376,16 +379,25 @@ namespace Netherlands3D.Twin.Layers
 
         private static bool IsAtTypeToken(JsonTextReader reader)
         {
+            if(reader.TokenType != JsonToken.PropertyName)
+                    return false;
+
             return reader.Value.ToString().ToLower() == "type";
         }
 
         private static bool IsAtCRSToken(JsonTextReader reader)
         {
+            if(reader.TokenType != JsonToken.PropertyName)
+                return false;
+
             return reader.Value.ToString().ToLower() == "crs";
         }
 
         private static bool IsAtFeaturesToken(JsonTextReader reader)
         {
+            if(reader.TokenType != JsonToken.PropertyName)
+                return false;
+
             return reader.Value.ToString().ToLower() == "features";
         }
     }


### PR DESCRIPTION
- strip possible query parameters ruining our import from url local filenames (for instance https://.../file.geojson?somequery=bleh
- make sure token type is PropertyName before checking property name value