### PR TITLE
Add the CurrentProject.asset ScriptableObject to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,8 @@ crashlytics-build.properties
 
 # Docker build artefacts
 /.docker/app-config.json
+
+# The default project when editing - changes are not committed because the ScriptableObject
+# changes when working on the project. If change is intentionally needed, use the command
+# `git add --force Assets/Scriptables/CurrentProject.asset` to force the changes to be committed.
+/[Aa]ssets/[Ss]criptables/CurrentProject.asset


### PR DESCRIPTION
Changes to the current project should not be committed because the ScriptableObject changes state while working on the project.

If a change is intentionally needed, use the following command to force the changes to be committed.

`git add --force Assets/Scriptables/CurrentProject.asset`