### PR TITLE
Bugfix/object library

### DIFF
--- a/Assets/Materials/ObjectLibrary/FerrisWheel/FerrisWheelFrame.mat
+++ b/Assets/Materials/ObjectLibrary/FerrisWheel/FerrisWheelFrame.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap:

--- a/Assets/Materials/ObjectLibrary/FerrisWheel/FerrisWheelHouse.mat
+++ b/Assets/Materials/ObjectLibrary/FerrisWheel/FerrisWheelHouse.mat
@@ -27,7 +27,7 @@ Material:
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap:

--- a/Assets/Models/FerrisWheel.fbx.meta
+++ b/Assets/Models/FerrisWheel.fbx.meta
@@ -32,7 +32,7 @@ ModelImporter:
     extraExposedTransformPaths: []
     extraUserProperties: []
     clipAnimations: []
-    isReadable: 0
+    isReadable: 1
   meshes:
     lODScreenPercentages: []
     globalScale: 1
@@ -90,7 +90,7 @@ ModelImporter:
     armStretch: 0.05
     legStretch: 0.05
     feetSpacing: 0
-    globalScale: 0.01
+    globalScale: 1
     rootMotionBoneName: 
     hasTranslationDoF: 0
     hasExtraRoot: 1

--- a/Assets/Scriptables/PrefabLibrary.asset
+++ b/Assets/Scriptables/PrefabLibrary.asset
@@ -36,7 +36,7 @@ MonoBehaviour:
     - {fileID: -7062163889935492721, guid: a324f799961a34de6967402e40a749dc, type: 3}
     - {fileID: -5293961980780918241, guid: e78ad354330e64902b24d08795d54efb, type: 3}
   - groupName: CustomLayers
-    autoPopulateUI: 1
+    autoPopulateUI: 0
     prefabs:
     - {fileID: 2578961074007820944, guid: 0dd48855510674827b667fa4abd5cf60, type: 3}
     - {fileID: 3749709991008444548, guid: acb0d28ce2b674042ba63bf1d7789bfd, type: 3}


### PR DESCRIPTION
Made custom layers not auto populate ui
Fixed settings of ferris wheel, the vert count exceeds the max for scattering, so it is currently not working yet
