### PR TITLE
fixed geojson layer visualisations not getting destroyed when layer is deleted

### DIFF
--- a/Assets/Scripts/Layers/LayerTypes/GeoJSONLineLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/GeoJSONLineLayer.cs
@@ -90,12 +90,12 @@ namespace Netherlands3D.Twin.Layers
             SpawnedVisualisations.Remove(featureVisualisation);
         }
 
-        public override void DestroyLayer()
+        public override void DestroyLayerGameObject()
         {
             if (Application.isPlaying)
                 GameObject.Destroy(LineRenderer3D.gameObject);
 
-            base.DestroyLayer();
+            base.DestroyLayerGameObject();
         }
     }
 }

--- a/Assets/Scripts/Layers/LayerTypes/GeoJSONPointLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/GeoJSONPointLayer.cs
@@ -87,12 +87,12 @@ namespace Netherlands3D.Twin.Layers
             SpawnedVisualisations.Remove(featureVisualisation);
         }
 
-        public override void DestroyLayer()
+        public override void DestroyLayerGameObject()
         {
             if (Application.isPlaying && PointRenderer3D && PointRenderer3D.gameObject)
                 GameObject.Destroy(PointRenderer3D.gameObject);
                 
-            base.DestroyLayer();
+            base.DestroyLayerGameObject();
         }
     }
 }

--- a/Assets/Scripts/Layers/LayerTypes/GeoJSONPolygonLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/GeoJSONPolygonLayer.cs
@@ -90,7 +90,7 @@ namespace Netherlands3D.Twin.Layers
             return polygonVisualizationMaterialInstance;
         }
 
-        public override void DestroyLayer()
+        public override void DestroyLayerGameObject()
         {
             // Remove all SpawnedVisualisations
             Debug.Log("Destroying all visualisations " + SpawnedVisualisations.Count);  
@@ -100,7 +100,7 @@ namespace Netherlands3D.Twin.Layers
                 RemoveFeature(featureVisualisation);
             }
 
-            base.DestroyLayer();
+            base.DestroyLayerGameObject();
         }
 
         /// <summary>

--- a/Assets/Scripts/Layers/LayerTypes/LayerGameObject.cs
+++ b/Assets/Scripts/Layers/LayerTypes/LayerGameObject.cs
@@ -96,12 +96,12 @@ namespace Netherlands3D.Twin.Layers
         {
         }
 
-        public virtual void DestroyLayer()
+        public void DestroyLayer()
         {
             layerData.DestroyLayer();
         }
 
-        public void DestroyLayerGameObject()
+        public virtual void DestroyLayerGameObject()
         {
             Destroy(gameObject);
         }


### PR DESCRIPTION
https://cdn-dev-ams-3da.azureedge.net/autobuild/bugfix/geojson-visualisations-stay-after-deletion/1119004618/