### PR TITLE
Changed upload-artefact from v2 to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
             ghcr.io/netherlands3d/twin:latest
 
       # Create an artifact in the build pipeline 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         name: Upload artifact to build pipeline
         with:
           name: Build


### PR DESCRIPTION
The build no longer works with upload-artefact@v2; according to the docs it seems to continue working with just a version bump; so let's try that out