### PR TITLE
In my previous fix to support WFS services with the outputFormat JSON…

### DIFF
--- a/Assets/Scripts/Layers/Adapters/DataTypeAdapters/WFSGeoJSONImportAdapter.cs
+++ b/Assets/Scripts/Layers/Adapters/DataTypeAdapters/WFSGeoJSONImportAdapter.cs
@@ -131,7 +131,7 @@ namespace Netherlands3D.Twin
             uriBuilder.SetQueryParameter("request", "GetFeature");
             uriBuilder.SetQueryParameter("version", wfsVersion);
             uriBuilder.SetQueryParameter("typeNames", featureType);
-            if (parameters.Get("outputFormat").ToLower() is not ("json" or "geojson"))
+            if (parameters.Get("outputFormat")?.ToLower() is not ("json" or "geojson"))
             {
                 uriBuilder.SetQueryParameter("outputFormat", "geojson");
             }


### PR DESCRIPTION
…, I introduced a null value exception when a WFS service without outputFormat parameter was provided. This fix introduces a null operator that will allow for the absence of the outputFormat parameter