### PR TITLE
Scrollen werkt niet bij download tool

### DIFF
--- a/Assets/Prefabs/UI/InspectorPanels/Download/DownloadInspector.prefab
+++ b/Assets/Prefabs/UI/InspectorPanels/Download/DownloadInspector.prefab
@@ -3133,6 +3133,7 @@ GameObject:
   m_Component:
   - component: {fileID: 688251476734183426}
   - component: {fileID: 4009584302880459875}
+  - component: {fileID: 8846528157045850036}
   m_Layer: 5
   m_Name: Content
   m_TagString: Untagged
@@ -3167,8 +3168,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0.0010153782}
-  m_SizeDelta: {x: 0, y: 300}
+  m_AnchoredPosition: {x: 0, y: -0.00005575391}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &4009584302880459875
 MonoBehaviour:
@@ -3196,6 +3197,20 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!114 &8846528157045850036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9190364833713474888}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 1
 --- !u!1001 &268576874816613286
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4839,7 +4854,7 @@ PrefabInstance:
     - target: {fileID: 5797817625417347508, guid: 115ed422e629e4645bfb5c97e46c2e9b,
         type: 3}
       propertyPath: m_Size
-      value: 0.99999887
+      value: 0.99989283
       objectReference: {fileID: 0}
     - target: {fileID: 5797817625417347508, guid: 115ed422e629e4645bfb5c97e46c2e9b,
         type: 3}


### PR DESCRIPTION
added contentsize fitter to content object measuring the vertical minimum size, now always keeping its content size updated. tested in multiple resolutions