### PR TITLE
Ensure correct query parameters escaping, and that we try to use the …

### DIFF
--- a/Assets/Scripts/CartesianTiles/WFSGeoJSONTileDataLayer.cs
+++ b/Assets/Scripts/CartesianTiles/WFSGeoJSONTileDataLayer.cs
@@ -140,6 +140,15 @@ namespace Netherlands3D.CartesianTiles
             {
                 ParseGeoJSON(geoJsonRequest.downloadHandler.text);
             }
+            else
+            {
+                // Show a message in the console, because otherwise you will never find out
+                // something went wrong. This should be replaced with a better error reporting
+                // system
+                Debug.LogWarning(
+                    $"Request to {url} failed with status code {geoJsonRequest.responseCode} and body \n{geoJsonRequest.downloadHandler.text}"
+                );
+            }
             callback?.Invoke(tileChange);
         }
 

--- a/Assets/Scripts/KeyVault/KeyVault.cs
+++ b/Assets/Scripts/KeyVault/KeyVault.cs
@@ -184,8 +184,6 @@ namespace Netherlands3D.Twin
             
             // Try input key as 'key' query parameter (remove a possible existing key query parameter and add the new one)
             var uriBuilder = new UriBuilder(url);
-            var queryParameters = new NameValueCollection();
-            uriBuilder.TryParseQueryString(queryParameters);
             uriBuilder.AddQueryParameter("key", key);
             var keyRequestUrl = UnityWebRequest.Get(uriBuilder.Uri);
             yield return keyRequestUrl.SendWebRequest();

--- a/Assets/Scripts/Layers/LayerTypes/WFSGeoJSONLayerGameObject.cs
+++ b/Assets/Scripts/Layers/LayerTypes/WFSGeoJSONLayerGameObject.cs
@@ -14,7 +14,8 @@ namespace Netherlands3D.Twin.Layers
         [SerializeField] private WFSGeoJSONTileDataLayer cartesianTileWFSLayer;
         public WFSGeoJSONTileDataLayer CartesianTileWFSLayer { get => cartesianTileWFSLayer; }
 
-        protected override void Awake() {
+        protected override void Awake() 
+        {
             base.Awake();
             
             CartesianTileWFSLayer.WFSGeoJSONLayer = this;


### PR DESCRIPTION
…correct output formats.

In Unity WebGL, when Api Compatibility Level is set to 2.1, there is an issue with EscapeDataString where it doesn't escape spaces. This is fixed in .NET 4.5.1 but enabling the .NET Framework compatibility level in WebGL builds is not recommended due to build sizes and issues with cross-browser compatibility.

Apparently, using Unity's own EscapeURL method on individual query parameter pieces will ensure correct escaping, so that solves the issue.

In addition, the default outputFormat for WFS is "application/json", or "application/json subtype=geojson" for GeoJSON. So I have improved the supported outputFormat determination to take this into account