### PR TITLE
Retain loaded position of an imported obj file

### DIFF
--- a/Assets/Prefabs/ObjImporter.prefab
+++ b/Assets/Prefabs/ObjImporter.prefab
@@ -1,0 +1,56 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3683644799359541447
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2552652701665730137}
+  - component: {fileID: 7917579944522795273}
+  m_Layer: 0
+  m_Name: ObjImporter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2552652701665730137
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3683644799359541447}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7917579944522795273
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3683644799359541447}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b6caa935ef381440b46ff58c21721cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  createdGameobjectIsMoveable: 0
+  gameObjectData:
+    name: 
+    materials: []
+    gameObjects: []
+  BaseMaterial: {fileID: 0}
+  objFilePath: 
+  mtlFilePath: 
+  imgFilePath: 
+  createSubMeshes: 0

--- a/Assets/Prefabs/ObjImporter.prefab.meta
+++ b/Assets/Prefabs/ObjImporter.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 17813655602a70c46a78e7f4ec2e2b97
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Layers/LayerTypes/ObjSpawner.cs
+++ b/Assets/Scripts/Layers/LayerTypes/ObjSpawner.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -19,6 +20,11 @@ namespace Netherlands3D.Twin.Layers
         public LayerPropertyData PropertyData => propertyData;
 
         private ObjImporter.ObjImporter importer;
+
+        private void Awake()
+        {
+            gameObject.transform.position = ObjectPlacementUtility.GetSpawnPoint();
+        }
 
         private void Start()
         {
@@ -68,8 +74,10 @@ namespace Netherlands3D.Twin.Layers
 
         private void OnObjImported(GameObject returnedGameObject)
         {
+            // By explicitly stating the worldPositionStays to false, we ensure Obj is spawned and it will retain the
+            // position and scale in this parent object
             returnedGameObject.transform.SetParent(this.transform, false);
-            AddLayerScriptToObj(returnedGameObject);
+            returnedGameObject.AddComponent<MeshCollider>();
 
             DisposeImporter();
         }
@@ -77,17 +85,6 @@ namespace Netherlands3D.Twin.Layers
         private void DisposeImporter()
         {
             if (importer != null) Destroy(importer.gameObject);
-        }
-        
-        private void AddLayerScriptToObj(GameObject parsedObj)
-        {
-            var spawnPoint = ObjectPlacementUtility.GetSpawnPoint();
-
-            gameObject.transform.position = spawnPoint;
-
-            parsedObj.AddComponent<MeshCollider>();
-
-            // CreatedMoveableGameObject.Invoke(parsedObj);
         }
     }
 }

--- a/Assets/Scripts/ObjectPlacementUtility.cs
+++ b/Assets/Scripts/ObjectPlacementUtility.cs
@@ -7,14 +7,17 @@ namespace Netherlands3D.Twin
         public static Vector3 GetSpawnPoint()
         {
             var camera = Camera.main;
-            var ray = camera.ScreenPointToRay(new Vector2(Screen.width / 2, Screen.height / 2));
+            var cameraTransform = camera.transform;
+
+            var ray = camera.ScreenPointToRay(new Vector2(Screen.width / 2f, Screen.height / 2f));
             var plane = new Plane(Vector3.up, 0);
             var intersect = plane.Raycast(ray, out float distance);
             if (!intersect)
+            {
                 distance = 10f;
+            }
 
-            var spawnPoint = camera.transform.position + camera.transform.forward * distance;
-            return spawnPoint;
+            return cameraTransform.position + cameraTransform.forward * distance;
         }
     }
 }

--- a/Assets/_BuildingBlocks/FloatingOrigin/Scripts/WorldTransform.cs
+++ b/Assets/_BuildingBlocks/FloatingOrigin/Scripts/WorldTransform.cs
@@ -8,15 +8,10 @@ namespace Netherlands3D.Twin.FloatingOrigin
     {
         [SerializeField] private WorldTransformShifter worldTransformShifter;
         [SerializeField] private CoordinateSystem referenceCoordinateSystem = CoordinateSystem.RDNAP;
-        public Coordinate Coordinate {
-            get;
-            set;
-        }
-        public Quaternion Rotation
-        {
-            get;
-            set;
-        }
+
+        public Coordinate Coordinate { get; set; } = new(CoordinateSystem.RDNAP);
+
+        public Quaternion Rotation { get; set; } = Quaternion.identity;
         public CoordinateSystem ReferenceCoordinateSystem => referenceCoordinateSystem;
         public Origin Origin => Origin.current;
 
@@ -56,7 +51,6 @@ namespace Netherlands3D.Twin.FloatingOrigin
             {
                 ShiftTo(Coordinate, Coordinate);
             }
-            
         }
 
         private void OnDisable()


### PR DESCRIPTION
In this PR, I have made the following changes:

- a bit of cleanup
- The HierarchicalLayerGameObject will now interact with the WorldTransform and use coordinates instead of transform.position; this will reduce edge cases involving shifts
- The SpawnPosition is now determined in the Awake instead of it being after importing the obj to make sure that positions set by external forces - such as loading a project- won't be overwritten by this default