### PR TITLE
Add the functionality to import Gltf and Glb files

### DIFF
--- a/Assets/Prefabs/UI/Layers/AddLayerPanel.prefab
+++ b/Assets/Prefabs/UI/Layers/AddLayerPanel.prefab
@@ -4743,7 +4743,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3a728a3527b1f334390e5bfd25ce6aa5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  fileExtentions: obj,csv,json,geojson
+  fileExtentions: obj,csv,json,geojson,glb,gltf
   multiSelect: 0
   onFilesSelected:
     m_PersistentCalls:

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -2177,7 +2177,7 @@ PrefabInstance:
     - target: {fileID: 1748615501916967598, guid: 0d52ffd9c87ab484b88610c4acf5db24,
         type: 3}
       propertyPath: fileExtentions
-      value: nl3d,obj,csv,json,geojson
+      value: nl3d,obj,csv,json,geojson,gltf,glb
       objectReference: {fileID: 0}
     - target: {fileID: 2388221261345448311, guid: 0d52ffd9c87ab484b88610c4acf5db24,
         type: 3}

--- a/Assets/Scriptables/DataTypeImportAdapters/FileTypeAdapter.asset
+++ b/Assets/Scriptables/DataTypeImportAdapters/FileTypeAdapter.asset
@@ -29,6 +29,40 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
+  - Extension: glb
+    FileReceived:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 11400000, guid: 32ff31abfa785a04b9ca89ebc8abcddc, type: 2}
+          m_TargetAssemblyTypeName: Netherlands3D.Twin.Functionalities.GltfImporter.GltfImportAdapter,
+            Assembly-CSharp
+          m_MethodName: Execute
+          m_Mode: 0
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - Extension: gltf
+    FileReceived:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 11400000, guid: 32ff31abfa785a04b9ca89ebc8abcddc, type: 2}
+          m_TargetAssemblyTypeName: Netherlands3D.Twin.Functionalities.GltfImporter.GltfImportAdapter,
+            Assembly-CSharp
+          m_MethodName: Execute
+          m_Mode: 0
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
   - Extension: csv
     FileReceived:
       m_PersistentCalls:

--- a/Assets/Scriptables/PrefabLibrary.asset
+++ b/Assets/Scriptables/PrefabLibrary.asset
@@ -55,3 +55,4 @@ MonoBehaviour:
     - {fileID: 2205593157182618917, guid: c57dd4a997e79ce43895144d0702166c, type: 3}
     - {fileID: 8209116542904522024, guid: 34882a73ff6122243a0e3e9811473e20, type: 3}
     - {fileID: 7611614742349668521, guid: 7ddb78a6acbf44d4e84910b5684042b7, type: 3}
+    - {fileID: 8209116542904522024, guid: a0c050d9c6beacb4593d8b7fccc08d05, type: 3}

--- a/Assets/Scriptables/PrefabLibrary.asset
+++ b/Assets/Scriptables/PrefabLibrary.asset
@@ -55,4 +55,4 @@ MonoBehaviour:
     - {fileID: 2205593157182618917, guid: c57dd4a997e79ce43895144d0702166c, type: 3}
     - {fileID: 8209116542904522024, guid: 34882a73ff6122243a0e3e9811473e20, type: 3}
     - {fileID: 7611614742349668521, guid: 7ddb78a6acbf44d4e84910b5684042b7, type: 3}
-    - {fileID: 8209116542904522024, guid: a0c050d9c6beacb4593d8b7fccc08d05, type: 3}
+    - {fileID: 1016696483101979518, guid: a0c050d9c6beacb4593d8b7fccc08d05, type: 3}

--- a/Assets/_Functionalities/GltfImporter.meta
+++ b/Assets/_Functionalities/GltfImporter.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 99cd6eca4d5b4b6eb347a25509f222d0
+timeCreated: 1729609517

--- a/Assets/_Functionalities/GltfImporter/GltfImporter.asset
+++ b/Assets/_Functionalities/GltfImporter/GltfImporter.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 714e859e1c414d479484fe937804ce24, type: 3}
+  m_Name: GltfImporter
+  m_EditorClassIdentifier: 
+  data:
+    Id: 3d-modellen-toevoegen
+    IsEnabled: 1
+  Title: 3D modellen toevoegen
+  Caption: Gltf / Glb
+  Header: Eigen .Gltf bestanden tonen in de 3D viewer
+  Description: "Maak het mogelijk jouw eigen .gltf of .glb modellen in de 3D wereld
+    te plaatsen. \n\nZorg dat het 3D model aan de volgende eisen voldoet:\n\n- Gltf
+    of Glb formaat\n- Maximaal 300MB bestandsgrootte\n"
+  configuration: {fileID: 0}
+  OnEnable:
+    m_PersistentCalls:
+      m_Calls: []
+  OnDisable:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/_Functionalities/GltfImporter/GltfImporter.asset.meta
+++ b/Assets/_Functionalities/GltfImporter/GltfImporter.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1a1a839e196ea364b8ee482eebb3e3f6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Functionalities/GltfImporter/Prefabs.meta
+++ b/Assets/_Functionalities/GltfImporter/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63d843effe7c2a648a73965d7df4d794
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Functionalities/GltfImporter/Prefabs/GltfLayer.prefab
+++ b/Assets/_Functionalities/GltfImporter/Prefabs/GltfLayer.prefab
@@ -1,0 +1,131 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9204913902124509902
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4013969559654378043}
+  - component: {fileID: 1016696483101979518}
+  - component: {fileID: 1646213389209705716}
+  - component: {fileID: 8128677453936289607}
+  - component: {fileID: 2362124063262672280}
+  - component: {fileID: 3482478533686408333}
+  - component: {fileID: 3094970985324844986}
+  m_Layer: 0
+  m_Name: GltfLayer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4013969559654378043
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9204913902124509902}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1016696483101979518
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9204913902124509902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 92795e992dcbe4b3c8ada171c5551674, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  prefabIdentifier: gltflayer
+  onShow:
+    m_PersistentCalls:
+      m_Calls: []
+  onHide:
+    m_PersistentCalls:
+      m_Calls: []
+  objectCreated:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1646213389209705716
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9204913902124509902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 630f741154ed48488dc6602ef25dab3a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  worldTransformShifter: {fileID: 8128677453936289607}
+  referenceCoordinateSystem: 2
+  onPreShift:
+    m_PersistentCalls:
+      m_Calls: []
+  onPostShift:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &8128677453936289607
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9204913902124509902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 50fab43e07a540b89d245bd4ec8e4887, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2362124063262672280
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9204913902124509902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8cceefce4ff4530b78245056d126688, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  propertySectionPrefab: {fileID: 964705144372893445, guid: b2b695c4876427c439761dd2521bf672,
+    type: 3}
+--- !u!114 &3482478533686408333
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9204913902124509902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ffc363b02a0945c7ad8cdc45e55f5ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3094970985324844986
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9204913902124509902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ec1a3dc060341bc9f895829eb82cc1e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/_Functionalities/GltfImporter/Prefabs/GltfLayer.prefab.meta
+++ b/Assets/_Functionalities/GltfImporter/Prefabs/GltfLayer.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a0c050d9c6beacb4593d8b7fccc08d05
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Functionalities/GltfImporter/ScriptableObjects.meta
+++ b/Assets/_Functionalities/GltfImporter/ScriptableObjects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b9c8b461cab3db9448997d05d94f9148
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Functionalities/GltfImporter/ScriptableObjects/GltfImportAdapter.asset
+++ b/Assets/_Functionalities/GltfImporter/ScriptableObjects/GltfImportAdapter.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72250ba7f5614f81ad22fff0a1354a4c, type: 3}
+  m_Name: GltfImportAdapter
+  m_EditorClassIdentifier: 
+  layerPrefab: {fileID: 3094970985324844986, guid: a0c050d9c6beacb4593d8b7fccc08d05,
+    type: 3}

--- a/Assets/_Functionalities/GltfImporter/ScriptableObjects/GltfImportAdapter.asset.meta
+++ b/Assets/_Functionalities/GltfImporter/ScriptableObjects/GltfImportAdapter.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 32ff31abfa785a04b9ca89ebc8abcddc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Functionalities/GltfImporter/Scripts.meta
+++ b/Assets/_Functionalities/GltfImporter/Scripts.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e3954afa414b42bba94ce8dde59578d4
+timeCreated: 1729609517

--- a/Assets/_Functionalities/GltfImporter/Scripts/GltfImportAdapter.cs
+++ b/Assets/_Functionalities/GltfImporter/Scripts/GltfImportAdapter.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using Netherlands3D.Twin.Layers.Properties;
+using Netherlands3D.Twin.Projects;
+using UnityEngine;
+
+namespace Netherlands3D.Twin.Functionalities.GltfImporter
+{
+    [CreateAssetMenu(menuName = "Netherlands3D/Adapters/GltfImportAdapter", fileName = "GltfImportAdapter", order = 0)]
+    public class GltfImportAdapter : ScriptableObject, IDataTypeAdapter
+    {
+        [SerializeField] private GltfSpawner layerPrefab;
+        
+        public bool Supports(LocalFile localFile)
+        {
+            return localFile.LocalFilePath.EndsWith(".glb") 
+                || localFile.LocalFilePath.EndsWith(".gltf");
+        }
+
+        public void Execute(LocalFile localFile)
+        {
+            var fullPath = localFile.LocalFilePath;
+            var fileName = Path.GetFileName(fullPath);
+            GltfSpawner newLayer = Instantiate(layerPrefab);
+            newLayer.gameObject.name = fileName;
+
+            var propertyData = newLayer.PropertyData as GltfPropertyData;
+            propertyData.Uri = AssetUriFactory.CreateProjectAssetUri(fullPath);
+        }
+    }
+}

--- a/Assets/_Functionalities/GltfImporter/Scripts/GltfImportAdapter.cs.meta
+++ b/Assets/_Functionalities/GltfImporter/Scripts/GltfImportAdapter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 72250ba7f5614f81ad22fff0a1354a4c
+timeCreated: 1729609517

--- a/Assets/_Functionalities/GltfImporter/Scripts/GltfPropertyData.cs
+++ b/Assets/_Functionalities/GltfImporter/Scripts/GltfPropertyData.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Netherlands3D.Twin.Layers;
+using Netherlands3D.Twin.Layers.Properties;
+using Newtonsoft.Json;
+using UnityEngine.Events;
+
+namespace Netherlands3D.Twin.Functionalities.GltfImporter
+{
+    [DataContract(Namespace = "https://netherlands3d.eu/schemas/projects/layers/properties", Name = "Gltf")]
+    public class GltfPropertyData : LayerPropertyData, ILayerPropertyDataWithAssets
+    {
+        [DataMember] private Uri uri;
+
+        [JsonIgnore] public readonly UnityEvent<Uri> OnUriChanged = new();
+
+        [JsonIgnore]
+        public Uri Uri
+        {
+            get => uri;
+            set
+            {
+                uri = value;
+                OnUriChanged.Invoke(value);
+            }
+        }
+
+        public IEnumerable<LayerAsset> GetAssets()
+        {
+            return new List<LayerAsset>
+            {
+                new (this, uri)
+            };
+        }
+    }
+}

--- a/Assets/_Functionalities/GltfImporter/Scripts/GltfPropertyData.cs.meta
+++ b/Assets/_Functionalities/GltfImporter/Scripts/GltfPropertyData.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4627542af8e2470e9f772142dcb69623
+timeCreated: 1729609517

--- a/Assets/_Functionalities/GltfImporter/Scripts/GltfSpawner.cs
+++ b/Assets/_Functionalities/GltfImporter/Scripts/GltfSpawner.cs
@@ -20,11 +20,16 @@ namespace Netherlands3D.Twin.Functionalities.GltfImporter
             gameObject.transform.position = ObjectPlacementUtility.GetSpawnPoint();
         }
 
-        private IEnumerator Start()
+        private void Start()
         {
             var localPath = propertyData.Uri.LocalPath.TrimStart('/', '\\');
             var path = Path.Combine(Application.persistentDataPath, localPath);
             
+            StartCoroutine(StartLoading(path));
+        }
+
+        private IEnumerator StartLoading(string path)
+        {
             yield return LoadModel(path);
         }
 
@@ -32,6 +37,7 @@ namespace Netherlands3D.Twin.Functionalities.GltfImporter
         {
             Debug.Log("Reading GLB/GLTF file");
             byte[] data = await File.ReadAllBytesAsync(path);
+            Debug.Log("Instantiate GltfImport");
             var gltf = new GltfImport();
             Debug.Log("Loading GLB/GLTF binary data");
             bool success = await gltf.LoadGltfBinary(data, new Uri(path));

--- a/Assets/_Functionalities/GltfImporter/Scripts/GltfSpawner.cs
+++ b/Assets/_Functionalities/GltfImporter/Scripts/GltfSpawner.cs
@@ -23,11 +23,19 @@ namespace Netherlands3D.Twin.Functionalities.GltfImporter
             var localPath = propertyData.Uri.LocalPath.TrimStart('/', '\\');
             var path = Path.Combine(Application.persistentDataPath, localPath);
             
+            Debug.Log("Reading GLB/GLTF file");
             byte[] data = await File.ReadAllBytesAsync(path);
             var gltf = new GltfImport();
+            Debug.Log("Loading GLB/GLTF binary data");
             bool success = await gltf.LoadGltfBinary(data, new Uri(path));
             if (success) {
+                Debug.Log("Creating Scene object(s) for GLB/GLTF");
                 await gltf.InstantiateMainSceneAsync(transform);
+                Debug.Log("Created Scene object(s) for GLB/GLTF");
+            }
+            else
+            {
+                Debug.LogError("Failed to load GLB/GLTF binary data");
             }
         }
 

--- a/Assets/_Functionalities/GltfImporter/Scripts/GltfSpawner.cs
+++ b/Assets/_Functionalities/GltfImporter/Scripts/GltfSpawner.cs
@@ -24,7 +24,7 @@ namespace Netherlands3D.Twin.Functionalities.GltfImporter
             var path = Path.Combine(Application.persistentDataPath, localPath);
             
             Debug.Log("Reading GLB/GLTF file");
-            byte[] data = await File.ReadAllBytesAsync(path);
+            byte[] data = File.ReadAllBytes(path);
             var gltf = new GltfImport();
             Debug.Log("Loading GLB/GLTF binary data");
             bool success = await gltf.LoadGltfBinary(data, new Uri(path));

--- a/Assets/_Functionalities/GltfImporter/Scripts/GltfSpawner.cs
+++ b/Assets/_Functionalities/GltfImporter/Scripts/GltfSpawner.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GLTFast;
+using Netherlands3D.Twin.Layers.Properties;
+using UnityEngine;
+
+namespace Netherlands3D.Twin.Functionalities.GltfImporter
+{
+    public class GltfSpawner : MonoBehaviour, ILayerWithPropertyData
+    {
+        private GltfPropertyData propertyData = new();
+        public LayerPropertyData PropertyData => propertyData;
+
+        private void Awake()
+        {
+            gameObject.transform.position = ObjectPlacementUtility.GetSpawnPoint();
+        }
+
+        private async void Start()
+        {
+            var localPath = propertyData.Uri.LocalPath.TrimStart('/', '\\');
+            var path = Path.Combine(Application.persistentDataPath, localPath);
+            
+            byte[] data = await File.ReadAllBytesAsync(path);
+            var gltf = new GltfImport();
+            bool success = await gltf.LoadGltfBinary(data, new Uri(path));
+            if (success) {
+                await gltf.InstantiateMainSceneAsync(transform);
+            }
+        }
+
+        public void LoadProperties(List<LayerPropertyData> properties)
+        {
+            var propertyData = properties.OfType<GltfPropertyData>().FirstOrDefault();
+            if (propertyData == null) return;
+
+            // Property data is set here, and the parsing and loading of the actual data is done
+            // in the start method, there a coroutine is started to load the data in a streaming fashion.
+            // If we do that here, then this may conflict with the loading of the project file and it would
+            // cause duplication when adding a layer manually instead of through the loading mechanism
+            this.propertyData = propertyData;
+        }
+    }
+}

--- a/Assets/_Functionalities/GltfImporter/Scripts/GltfSpawner.cs
+++ b/Assets/_Functionalities/GltfImporter/Scripts/GltfSpawner.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using GLTFast;
 using Netherlands3D.Twin.Layers.Properties;
 using UnityEngine;
@@ -18,25 +20,30 @@ namespace Netherlands3D.Twin.Functionalities.GltfImporter
             gameObject.transform.position = ObjectPlacementUtility.GetSpawnPoint();
         }
 
-        private async void Start()
+        private IEnumerator Start()
         {
             var localPath = propertyData.Uri.LocalPath.TrimStart('/', '\\');
             var path = Path.Combine(Application.persistentDataPath, localPath);
             
+            yield return LoadModel(path);
+        }
+
+        private async Task LoadModel(string path)
+        {
             Debug.Log("Reading GLB/GLTF file");
-            byte[] data = File.ReadAllBytes(path);
+            byte[] data = await File.ReadAllBytesAsync(path);
             var gltf = new GltfImport();
             Debug.Log("Loading GLB/GLTF binary data");
             bool success = await gltf.LoadGltfBinary(data, new Uri(path));
-            if (success) {
-                Debug.Log("Creating Scene object(s) for GLB/GLTF");
-                await gltf.InstantiateMainSceneAsync(transform);
-                Debug.Log("Created Scene object(s) for GLB/GLTF");
-            }
-            else
+            if (!success)
             {
                 Debug.LogError("Failed to load GLB/GLTF binary data");
+                return;
             }
+
+            Debug.Log("Creating Scene object(s) for GLB/GLTF");
+            await gltf.InstantiateMainSceneAsync(transform);
+            Debug.Log("Created Scene object(s) for GLB/GLTF");
         }
 
         public void LoadProperties(List<LayerPropertyData> properties)

--- a/Assets/_Functionalities/GltfImporter/Scripts/GltfSpawner.cs.meta
+++ b/Assets/_Functionalities/GltfImporter/Scripts/GltfSpawner.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4ec1a3dc060341bc9f895829eb82cc1e
+timeCreated: 1729609517


### PR DESCRIPTION
This commit will add the importer, spawner and layer prefabs to import, persist and load a Gltf/Glb file.

There is however the issue of textures not loading, but I think this has to do with the changes that we did to limit the number of shader variants for Gltfast; and as such stripping the texture loading.