### PR TITLE
Retrieve and display Amsterdam Time Machine information

### DIFF
--- a/Assets/Prefabs/UI/Components/Object_Information/Foto element.prefab
+++ b/Assets/Prefabs/UI/Components/Object_Information/Foto element.prefab
@@ -146,9 +146,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Netherlands3D.Twin.DownloadGeoJSON, Assembly-CSharp
-        m_MethodName: DownloadFileFromURL
+      - m_Target: {fileID: 314689352903473804}
+        m_TargetAssemblyTypeName: Netherlands3D.Twin.AtmInformationListItem, Assembly-CSharp
+        m_MethodName: Open
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -241,6 +241,7 @@ GameObject:
   - component: {fileID: 7823922722719253330}
   - component: {fileID: 2373743494144311157}
   - component: {fileID: 5471916875883121308}
+  - component: {fileID: 314689352903473804}
   m_Layer: 5
   m_Name: Foto element
   m_TagString: Untagged
@@ -328,6 +329,22 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &314689352903473804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1819709314307839895}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 08cb7ab29cdad574e91cb3fa5ba7a941, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  thumbnailPlaceholder: {fileID: 0}
+  titleField: {fileID: 7135416982533806912}
+  subTextField: {fileID: 8137651330941699210}
+  photoField: {fileID: 6306539367379105678}
 --- !u!1 &2793399166716847095
 GameObject:
   m_ObjectHideFlags: 0
@@ -436,7 +453,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 46.699646, y: -15.2496}
-  m_SizeDelta: {x: 26.91, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4131925075457128519
 CanvasRenderer:

--- a/Assets/Prefabs/UI/Components/Object_Information/Link element.prefab
+++ b/Assets/Prefabs/UI/Components/Object_Information/Link element.prefab
@@ -570,9 +570,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: Netherlands3D.Twin.DownloadGeoJSON, Assembly-CSharp
-        m_MethodName: DownloadFileFromURL
+      - m_Target: {fileID: 1830248112927896688}
+        m_TargetAssemblyTypeName: Netherlands3D.Twin.AtmInformationListItem, Assembly-CSharp
+        m_MethodName: Open
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -665,6 +665,7 @@ GameObject:
   - component: {fileID: 3371769265685361677}
   - component: {fileID: 7111180695893248042}
   - component: {fileID: 697742808537251267}
+  - component: {fileID: 1830248112927896688}
   m_Layer: 5
   m_Name: Link element
   m_TagString: Untagged
@@ -750,6 +751,22 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1830248112927896688
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6565722629578252488}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 08cb7ab29cdad574e91cb3fa5ba7a941, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  thumbnailPlaceholder: {fileID: 0}
+  titleField: {fileID: 2402901280461630495}
+  dateField: {fileID: 0}
+  photoField: {fileID: 0}
 --- !u!1 &8825158940194595873
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/Sidebar/SpecificComponents/ExtraObjectInformation.prefab
+++ b/Assets/Prefabs/UI/Sidebar/SpecificComponents/ExtraObjectInformation.prefab
@@ -545,6 +545,7 @@ GameObject:
   - component: {fileID: 6778223411237904173}
   - component: {fileID: 4349820417869818976}
   - component: {fileID: 9055248403649816541}
+  - component: {fileID: 5758701200439614367}
   m_Layer: 5
   m_Name: ExtraObjectInformation
   m_TagString: Untagged
@@ -664,6 +665,23 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 2
+--- !u!114 &5758701200439614367
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5078733024073835164}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6103d712deb081047b620bd56f3691b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  contentArea: {fileID: 4153153229033263703}
+  photoListItem: {fileID: 314689352903473804, guid: 7f00825835c267d4283dbc9a276fe4fd,
+    type: 3}
+  regularListItem: {fileID: 1830248112927896688, guid: 0b8549ff4f869d94a8f4f9027b731916,
+    type: 3}
 --- !u!1 &5422203556322709958
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -9113,7 +9113,7 @@ PrefabInstance:
       addedObject: {fileID: 645481521}
     - targetCorrespondingSourceObject: {fileID: 2773908478669454240, guid: 9963fec33e379324db2affcb3f83332f,
         type: 3}
-      insertIndex: 2
+      insertIndex: 1
       addedObject: {fileID: 1810673488}
     - targetCorrespondingSourceObject: {fileID: 8632740765308209879, guid: 9963fec33e379324db2affcb3f83332f,
         type: 3}

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -2767,11 +2767,6 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 717174223129455007, guid: 9963fec33e379324db2affcb3f83332f,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 762974672070025286, guid: 9963fec33e379324db2affcb3f83332f,
         type: 3}
       propertyPath: m_Interactable

--- a/Assets/_Functionalities/AmsterdamTimeMachine.meta
+++ b/Assets/_Functionalities/AmsterdamTimeMachine.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc2e2edb4b793da42a40b892f48eb02d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Functionalities/AmsterdamTimeMachine/Scripts.meta
+++ b/Assets/_Functionalities/AmsterdamTimeMachine/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed1f8f8e3b7b93f4ba91154d2cb5f529
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Functionalities/AmsterdamTimeMachine/Scripts/Ui.meta
+++ b/Assets/_Functionalities/AmsterdamTimeMachine/Scripts/Ui.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 55dab397c096ee54fa787e7089e8e5b0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Functionalities/AmsterdamTimeMachine/Scripts/Ui/AtmInformationList.cs
+++ b/Assets/_Functionalities/AmsterdamTimeMachine/Scripts/Ui/AtmInformationList.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using KindMen.Uxios;
+using KindMen.Uxios.Api;
+using UnityEngine;
+using QueryParameters = KindMen.Uxios.Http.QueryParameters;
+
+namespace Netherlands3D.Twin
+{
+    public class AtmInformationList : MonoBehaviour
+    {
+        public class AtmInfo
+        {
+            public string url;
+            public string title;
+            public string startDate;
+            public string endDate;
+            public string textDate;
+            public string thumbnail;
+
+            public override string ToString()
+            {
+                return $"{{url: {url}, title: {title}, startDate: {startDate}, endDate: {endDate}, textDate: {textDate}, thumbnail: {thumbnail}}}";
+            }
+        }
+
+        [SerializeField] private GameObject contentArea;
+        [SerializeField] private AtmInformationListItem photoListItem;
+        [SerializeField] private AtmInformationListItem regularListItem;
+        private const string bagUriTemplate = "https://api.lod.uba.uva.nl/queries/ATM/images-building-nl3d/2/run?bag=http://bag.basisregistraties.overheid.nl/bag/id/pand/{id}";
+        private const string adamLinkTemplate = "https://api.lod.uba.uva.nl/queries/ATM/images-historical-address-nl3d/2/run?address=https://adamlink.nl/geo/address/{id}";
+
+        public void LoadFromBagId(string bagId)
+        {
+            QueryParameters parameters = new() {{"id", bagId}};
+
+            PopulateList(new TemplatedUri(bagUriTemplate, parameters));
+        }
+
+        public void LoadFromFeature(FeatureMapping featureMapping)
+        {
+            var adamLinkId = featureMapping.Feature.Properties["id"]?.ToString();
+            QueryParameters parameters = new() {{"id", adamLinkId}};
+
+            PopulateList(new TemplatedUri(adamLinkTemplate, parameters));
+        }
+
+        private void PopulateList(Uri url)
+        {
+            contentArea.transform.ClearAllChildren();
+
+            var promise = Resource<List<AtmInfo>>.At(url).Value;
+            promise.Then(CreateListItems);
+            promise.Catch(OnErrorDuringLoading);
+        }
+
+        private void OnErrorDuringLoading(Exception exception)
+        {
+            var error = exception as Error;
+            
+            Debug.LogError(
+                $"An issue occurred while loading data from ATM ({error?.Request.Url}):\n{exception.Message}"
+            );
+        }
+
+        private void CreateListItems(List<AtmInfo> atmInformationObjects)
+        {
+            foreach (var atmInfo in atmInformationObjects)
+            {
+                CreateListItem(atmInfo);
+            }
+        }
+
+        private void CreateListItem(AtmInfo atmInfo)
+        {
+            var listItemPrefab = string.IsNullOrEmpty(atmInfo.thumbnail) ? regularListItem : photoListItem;
+            var listItem = Instantiate(listItemPrefab, contentArea.transform);
+            listItem.SetAtmInfo(atmInfo);
+        }
+    }
+}

--- a/Assets/_Functionalities/AmsterdamTimeMachine/Scripts/Ui/AtmInformationList.cs
+++ b/Assets/_Functionalities/AmsterdamTimeMachine/Scripts/Ui/AtmInformationList.cs
@@ -28,7 +28,7 @@ namespace Netherlands3D.Twin
         [SerializeField] private AtmInformationListItem photoListItem;
         [SerializeField] private AtmInformationListItem regularListItem;
         private const string bagUriTemplate = "https://api.lod.uba.uva.nl/queries/ATM/images-building-nl3d/2/run?bag=http://bag.basisregistraties.overheid.nl/bag/id/pand/{id}";
-        private const string adamLinkTemplate = "https://api.lod.uba.uva.nl/queries/ATM/images-historical-address-nl3d/2/run?address=https://adamlink.nl/geo/address/{id}";
+        private const string adamLinkTemplate = "https://api.lod.uba.uva.nl/queries/ATM/images-historical-address-nl3d/2/run?address={id}";
 
         public void LoadFromBagId(string bagId)
         {
@@ -40,6 +40,13 @@ namespace Netherlands3D.Twin
         public void LoadFromFeature(FeatureMapping featureMapping)
         {
             var adamLinkId = featureMapping.Feature.Properties["id"]?.ToString();
+
+            // check for an id field, otherwise it is not an Amsterdam Time Machine feature
+            if (string.IsNullOrEmpty(adamLinkId)) return;
+            
+            // check if it is a valid Amsterdam Time Machine feature, otherwise we ignore it 
+            if (adamLinkId.StartsWith("https://adamlink.nl/geo/address/") == false) return;
+
             QueryParameters parameters = new() {{"id", adamLinkId}};
 
             PopulateList(new TemplatedUri(adamLinkTemplate, parameters));

--- a/Assets/_Functionalities/AmsterdamTimeMachine/Scripts/Ui/AtmInformationList.cs.meta
+++ b/Assets/_Functionalities/AmsterdamTimeMachine/Scripts/Ui/AtmInformationList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6103d712deb081047b620bd56f3691b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Functionalities/AmsterdamTimeMachine/Scripts/Ui/AtmInformationListItem.cs
+++ b/Assets/_Functionalities/AmsterdamTimeMachine/Scripts/Ui/AtmInformationListItem.cs
@@ -1,0 +1,69 @@
+using KindMen.Uxios.Api;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Netherlands3D.Twin
+{
+    public class AtmInformationListItem : MonoBehaviour
+    {
+        private AtmInformationList.AtmInfo atmInfo;
+        
+        [SerializeField] private Texture2D thumbnailPlaceholder;
+        [SerializeField] private TMP_Text titleField;
+        [SerializeField] private TMP_Text subTextField;
+        [SerializeField] private RawImage photoField;
+
+        public void SetAtmInfo(AtmInformationList.AtmInfo atmInfo)
+        {
+            this.atmInfo = atmInfo;
+            gameObject.name = this.atmInfo.title;
+
+            SetTitle();
+            SetSubText();
+            LoadThumbnail();
+        }
+
+        private void SetTitle()
+        {
+            if (!titleField) return;
+
+            titleField.text = atmInfo.title;
+        }
+
+        private void SetSubText()
+        {
+            if (!subTextField) return;
+
+            subTextField.text = atmInfo.textDate;
+        }
+
+        private void SetThumbnail(Texture2D texture)
+        {
+            if (!photoField) return;
+
+            photoField.texture = texture;
+        }
+
+        private void LoadThumbnail()
+        {
+            // Re-set thumbnail to the placeholder image
+            SetThumbnail(thumbnailPlaceholder);
+            
+            // No photo field set - no thumbnail can be shown
+            if (!photoField) return;
+            
+            // No thumbnail present in the atm information - no thumbnail can be shown
+            if (string.IsNullOrEmpty(atmInfo.thumbnail)) return;
+            
+            // Get it!
+            var resource = Resource<Texture2D>.At(atmInfo.thumbnail);
+            resource.Value.Then(SetThumbnail);
+        }
+
+        public void Open()
+        {
+            Application.OpenURL(atmInfo.url);
+        }
+    }
+}

--- a/Assets/_Functionalities/AmsterdamTimeMachine/Scripts/Ui/AtmInformationListItem.cs.meta
+++ b/Assets/_Functionalities/AmsterdamTimeMachine/Scripts/Ui/AtmInformationListItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 08cb7ab29cdad574e91cb3fa5ba7a941
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Functionalities/ObjectInformation/Prefabs/ObjectInspector.prefab
+++ b/Assets/_Functionalities/ObjectInformation/Prefabs/ObjectInspector.prefab
@@ -153,6 +153,7 @@ GameObject:
   - component: {fileID: 2688462733659480497}
   - component: {fileID: 9122227890730904662}
   - component: {fileID: 326909105759611024}
+  - component: {fileID: 5229123283060670719}
   m_Layer: 5
   m_Name: FeatureInformation
   m_TagString: Untagged
@@ -177,9 +178,9 @@ RectTransform:
   m_Father: {fileID: 4996155142956460685}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -829.64}
+  m_SizeDelta: {x: 1895, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &9122227890730904662
 MonoBehaviour:
@@ -221,6 +222,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 2
+--- !u!114 &5229123283060670719
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2809667015185763040}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ffd3f0c60922f1b4a9ed734b4a78d8e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &5529894738576217112
 GameObject:
   m_ObjectHideFlags: 0
@@ -363,6 +376,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 6891717475724219592}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
   FeatureSelected:
     m_PersistentCalls:
       m_Calls:
@@ -391,6 +416,18 @@ MonoBehaviour:
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 6891717475724219592}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
         m_CallState: 2
   Deselected:
     m_PersistentCalls:
@@ -447,6 +484,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 6891717475724219592}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &3327197618826175379
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -485,6 +534,7 @@ GameObject:
   - component: {fileID: 2185119870173728605}
   - component: {fileID: 8517154521949974544}
   - component: {fileID: 8976774012347650358}
+  - component: {fileID: 8478133793875167888}
   m_Layer: 5
   m_Name: BuildingInformation
   m_TagString: Untagged
@@ -515,9 +565,9 @@ RectTransform:
   m_Father: {fileID: 4996155142956460685}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -383.64}
+  m_SizeDelta: {x: 1895, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &8517154521949974544
 MonoBehaviour:
@@ -559,6 +609,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 2
+--- !u!114 &8478133793875167888
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7280905012064880113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ffd3f0c60922f1b4a9ed734b4a78d8e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8460678307647717199
 GameObject:
   m_ObjectHideFlags: 0
@@ -569,6 +631,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4996155142956460685}
   - component: {fileID: 1366947644818311959}
+  - component: {fileID: 8702486949596303377}
   m_Layer: 5
   m_Name: Content
   m_TagString: Untagged
@@ -591,6 +654,7 @@ RectTransform:
   - {fileID: 3519849611235651744}
   - {fileID: 2185119870173728605}
   - {fileID: 2688462733659480497}
+  - {fileID: 2282799692021290364}
   m_Father: {fileID: 5738221700634465925}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -612,6 +676,32 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 2
+--- !u!114 &8702486949596303377
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8460678307647717199}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 16
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 16
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &8892486590444065404
 GameObject:
   m_ObjectHideFlags: 0
@@ -736,9 +826,9 @@ RectTransform:
   m_Father: {fileID: 4996155142956460685}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 2, y: -0}
-  m_SizeDelta: {x: -22, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0}
+  m_SizeDelta: {x: 1895, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1251321066847446360
 MonoBehaviour:
@@ -1301,6 +1391,467 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1447910659025576347}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1864213448780658260
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 4996155142956460685}
+    m_Modifications:
+    - target: {fileID: 178689738648333224, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 178689738648333224, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 178689738648333224, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 146.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 178689738648333224, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 16.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 178689738648333224, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 116.9306
+      objectReference: {fileID: 0}
+    - target: {fileID: 178689738648333224, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -15.2496
+      objectReference: {fileID: 0}
+    - target: {fileID: 350843438612364259, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1895
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 947.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -1658.3359
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1389967864631557269, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1389967864631557269, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1389967864631557269, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1389967864631557269, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1389967864631557269, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1485832949817359289, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1485832949817359289, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2688885768907903522, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2688885768907903522, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2688885768907903522, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 19.244648
+      objectReference: {fileID: 0}
+    - target: {fileID: 2688885768907903522, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -15.2496
+      objectReference: {fileID: 0}
+    - target: {fileID: 3169865208320246744, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3169865208320246744, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3169865208320246744, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3169865208320246744, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3169865208320246744, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3976998761925728002, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3976998761925728002, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3976998761925728002, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3976998761925728002, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3976998761925728002, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4151311211915888376, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4151311211915888376, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4151311211915888376, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 19.244648
+      objectReference: {fileID: 0}
+    - target: {fileID: 4151311211915888376, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -15.2496
+      objectReference: {fileID: 0}
+    - target: {fileID: 4787387858675682212, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4787387858675682212, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4787387858675682212, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 26.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 4787387858675682212, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 16.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 4787387858675682212, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 46.699646
+      objectReference: {fileID: 0}
+    - target: {fileID: 4787387858675682212, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -15.2496
+      objectReference: {fileID: 0}
+    - target: {fileID: 5078733024073835164, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_Name
+      value: AtmInformation
+      objectReference: {fileID: 0}
+    - target: {fileID: 5381855212316052579, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.00015330517
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826484198114451326, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826484198114451326, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826484198114451326, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 26.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826484198114451326, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 16.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826484198114451326, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 46.699646
+      objectReference: {fileID: 0}
+    - target: {fileID: 6826484198114451326, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -15.2496
+      objectReference: {fileID: 0}
+    - target: {fileID: 7303209008131617326, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7303209008131617326, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7303209008131617326, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 29.7706
+      objectReference: {fileID: 0}
+    - target: {fileID: 7303209008131617326, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -15.2496
+      objectReference: {fileID: 0}
+    - target: {fileID: 8065810425275369335, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8065810425275369335, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8065810425275369335, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8065810425275369335, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8065810425275369335, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8382081628460066854, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8382081628460066854, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8382081628460066854, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8591673984490518286, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8591673984490518286, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8591673984490518286, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 657.37274
+      objectReference: {fileID: 0}
+    - target: {fileID: 8591673984490518286, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 328.68637
+      objectReference: {fileID: 0}
+    - target: {fileID: 8591673984490518286, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -25.3449
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637168638281038544, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      propertyPath: m_Value
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5078733024073835164, guid: c906505ed49b0284e96f1ea7399752e7,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6265833245797941791}
+  m_SourcePrefab: {fileID: 100100000, guid: c906505ed49b0284e96f1ea7399752e7, type: 3}
+--- !u!224 &2282799692021290364 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 464194535855973160, guid: c906505ed49b0284e96f1ea7399752e7,
+    type: 3}
+  m_PrefabInstance: {fileID: 1864213448780658260}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6891717475724219592 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5078733024073835164, guid: c906505ed49b0284e96f1ea7399752e7,
+    type: 3}
+  m_PrefabInstance: {fileID: 1864213448780658260}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6265833245797941791
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6891717475724219592}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ffd3f0c60922f1b4a9ed734b4a78d8e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1984807725534334271
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2183,7 +2734,7 @@ PrefabInstance:
     - target: {fileID: 464194535855973160, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1889
+      value: 1893
       objectReference: {fileID: 0}
     - target: {fileID: 464194535855973160, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
@@ -2228,7 +2779,7 @@ PrefabInstance:
     - target: {fileID: 464194535855973160, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 946.5
+      value: 948.5
       objectReference: {fileID: 0}
     - target: {fileID: 464194535855973160, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
@@ -2368,7 +2919,7 @@ PrefabInstance:
     - target: {fileID: 5381855212316052579, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.000518874
+      value: 0.00012293551
       objectReference: {fileID: 0}
     - target: {fileID: 8065810425275369335, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
@@ -2725,12 +3276,12 @@ PrefabInstance:
     - target: {fileID: 5797817625417347508, guid: 115ed422e629e4645bfb5c97e46c2e9b,
         type: 3}
       propertyPath: m_Size
-      value: 1
+      value: 0.5541189
       objectReference: {fileID: 0}
     - target: {fileID: 5797817625417347508, guid: 115ed422e629e4645bfb5c97e46c2e9b,
         type: 3}
       propertyPath: m_Value
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/_Functionalities/ObjectInformation/Prefabs/ObjectInspector.prefab
+++ b/Assets/_Functionalities/ObjectInformation/Prefabs/ObjectInspector.prefab
@@ -334,6 +334,119 @@ MonoBehaviour:
   placeholderPanel: {fileID: 8986235331824895525}
   buildingContentPanel: {fileID: 7280905012064880113}
   featureContentPanel: {fileID: 2809667015185763040}
+  BuildingSelected:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4191480216153404035}
+        m_TargetAssemblyTypeName: Netherlands3D.Twin.Interface.BAG.BagInspector,
+          Assembly-CSharp
+        m_MethodName: ShowObjectInformation
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 3250020502134624231}
+        m_TargetAssemblyTypeName: Netherlands3D.Twin.ObjectInformation.SubObjectSelector,
+          Assembly-CSharp
+        m_MethodName: Select
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  FeatureSelected:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4191480216153404035}
+        m_TargetAssemblyTypeName: Netherlands3D.Twin.Interface.BAG.BagInspector,
+          Assembly-CSharp
+        m_MethodName: ShowFeatureInformation
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 3327197618826175379}
+        m_TargetAssemblyTypeName: Netherlands3D.Twin.ObjectInformation.FeatureSelector,
+          Assembly-CSharp
+        m_MethodName: Select
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  Deselected:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4191480216153404035}
+        m_TargetAssemblyTypeName: Netherlands3D.Twin.Interface.BAG.BagInspector,
+          Assembly-CSharp
+        m_MethodName: HideFeatureInformation
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 4191480216153404035}
+        m_TargetAssemblyTypeName: Netherlands3D.Twin.Interface.BAG.BagInspector,
+          Assembly-CSharp
+        m_MethodName: HideObjectInformation
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 3327197618826175379}
+        m_TargetAssemblyTypeName: Netherlands3D.Twin.ObjectInformation.FeatureSelector,
+          Assembly-CSharp
+        m_MethodName: Deselect
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 3250020502134624231}
+        m_TargetAssemblyTypeName: Netherlands3D.Twin.ObjectInformation.SubObjectSelector,
+          Assembly-CSharp
+        m_MethodName: Deselect
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &3327197618826175379
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2070,7 +2183,7 @@ PrefabInstance:
     - target: {fileID: 464194535855973160, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1898
+      value: 1889
       objectReference: {fileID: 0}
     - target: {fileID: 464194535855973160, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
@@ -2115,7 +2228,7 @@ PrefabInstance:
     - target: {fileID: 464194535855973160, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 951
+      value: 946.5
       objectReference: {fileID: 0}
     - target: {fileID: 464194535855973160, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
@@ -2175,12 +2288,12 @@ PrefabInstance:
     - target: {fileID: 1485832949817359289, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1485832949817359289, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1485832949817359289, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
@@ -2245,7 +2358,7 @@ PrefabInstance:
     - target: {fileID: 4544874626990740323, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5078733024073835164, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
@@ -2255,7 +2368,7 @@ PrefabInstance:
     - target: {fileID: 5381855212316052579, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.0005766329
+      value: 0.000518874
       objectReference: {fileID: 0}
     - target: {fileID: 8065810425275369335, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
@@ -2492,7 +2605,7 @@ PrefabInstance:
     - target: {fileID: 1781802643554129927, guid: 115ed422e629e4645bfb5c97e46c2e9b,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3286731148600885667, guid: 115ed422e629e4645bfb5c97e46c2e9b,
         type: 3}
@@ -2597,12 +2710,12 @@ PrefabInstance:
     - target: {fileID: 3690174632879616221, guid: 115ed422e629e4645bfb5c97e46c2e9b,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3690174632879616221, guid: 115ed422e629e4645bfb5c97e46c2e9b,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3690174632879616221, guid: 115ed422e629e4645bfb5c97e46c2e9b,
         type: 3}
@@ -2899,12 +3012,12 @@ PrefabInstance:
     - target: {fileID: 5600597860905115593, guid: 94f30d1acd3790145be90ba474006eed,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5600597860905115593, guid: 94f30d1acd3790145be90ba474006eed,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5600597860905115593, guid: 94f30d1acd3790145be90ba474006eed,
         type: 3}
@@ -2919,7 +3032,7 @@ PrefabInstance:
     - target: {fileID: 7572964915398819101, guid: 94f30d1acd3790145be90ba474006eed,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/_Functionalities/ObjectInformation/Prefabs/ObjectInspector.prefab
+++ b/Assets/_Functionalities/ObjectInformation/Prefabs/ObjectInspector.prefab
@@ -388,6 +388,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
+      - m_Target: {fileID: 6211590310770912715}
+        m_TargetAssemblyTypeName: Netherlands3D.Twin.AtmInformationList, Assembly-CSharp
+        m_MethodName: LoadFromBagId
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
   FeatureSelected:
     m_PersistentCalls:
       m_Calls:
@@ -421,6 +433,18 @@ MonoBehaviour:
         m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
         m_MethodName: SetActive
         m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 6211590310770912715}
+        m_TargetAssemblyTypeName: Netherlands3D.Twin.AtmInformationList, Assembly-CSharp
+        m_MethodName: LoadFromFeature
+        m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1587,7 +1611,7 @@ PrefabInstance:
     - target: {fileID: 2688885768907903522, guid: c906505ed49b0284e96f1ea7399752e7,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -15.2496
+      value: -15.249603
       objectReference: {fileID: 0}
     - target: {fileID: 3169865208320246744, guid: c906505ed49b0284e96f1ea7399752e7,
         type: 3}
@@ -1697,7 +1721,7 @@ PrefabInstance:
     - target: {fileID: 5381855212316052579, guid: c906505ed49b0284e96f1ea7399752e7,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.00015330517
+      value: 0.000019848347
       objectReference: {fileID: 0}
     - target: {fileID: 6826484198114451326, guid: c906505ed49b0284e96f1ea7399752e7,
         type: 3}
@@ -1825,7 +1849,7 @@ PrefabInstance:
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 5078733024073835164, guid: c906505ed49b0284e96f1ea7399752e7,
         type: 3}
-      insertIndex: -1
+      insertIndex: 6
       addedObject: {fileID: 6265833245797941791}
   m_SourcePrefab: {fileID: 100100000, guid: c906505ed49b0284e96f1ea7399752e7, type: 3}
 --- !u!224 &2282799692021290364 stripped
@@ -1834,6 +1858,18 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1864213448780658260}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &6211590310770912715 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5758701200439614367, guid: c906505ed49b0284e96f1ea7399752e7,
+    type: 3}
+  m_PrefabInstance: {fileID: 1864213448780658260}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6891717475724219592}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6103d712deb081047b620bd56f3691b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6891717475724219592 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5078733024073835164, guid: c906505ed49b0284e96f1ea7399752e7,
@@ -2919,7 +2955,7 @@ PrefabInstance:
     - target: {fileID: 5381855212316052579, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.00012293551
+      value: 0.00049917254
       objectReference: {fileID: 0}
     - target: {fileID: 8065810425275369335, guid: 72950be68ca8c494bb05ced5a5bba524,
         type: 3}

--- a/Assets/_Functionalities/ObjectInformation/Scripts/BagInspector.cs
+++ b/Assets/_Functionalities/ObjectInformation/Scripts/BagInspector.cs
@@ -10,6 +10,7 @@ using Netherlands3D.Twin.Layers;
 using Netherlands3D.Twin.ObjectInformation;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Events;
 using UnityEngine.InputSystem;
 using UnityEngine.Networking;
 
@@ -52,6 +53,10 @@ namespace Netherlands3D.Twin.Interface.BAG
 		[SerializeField] private GameObject placeholderPanel;
 		[SerializeField] private GameObject buildingContentPanel;
         [SerializeField] private GameObject featureContentPanel;
+
+        public UnityEvent<string> BuildingSelected = new();
+        public UnityEvent<FeatureMapping> FeatureSelected = new();
+        public UnityEvent Deselected = new();
 
         private Camera mainCamera;
 		private CameraInputSystemProvider cameraInputSystemProvider;
@@ -189,17 +194,14 @@ namespace Netherlands3D.Twin.Interface.BAG
 
         private void SelectBuildingOnHit(string bagId)
 		{
-            ShowObjectInformation();
-
-            subObjectSelector.Select(bagId);
+			BuildingSelected.Invoke(bagId);
 			LoadBuildingContent(bagId);
 		}
 		
 		private void SelectFeatureOnHit(FeatureMapping mapping)
 		{          
-            ShowFeatureInformation();
+			FeatureSelected.Invoke(mapping);
 			ExtrudePointsForSelection(mapping);
-            featureSelector.Select(mapping);
 			LoadFeatureContent(mapping);
 			RenderThumbnailForFeature(mapping);            
         }
@@ -276,11 +278,7 @@ namespace Netherlands3D.Twin.Interface.BAG
 
 		private void Deselect()
 		{
-            HideObjectInformation();
-			HideFeatureInformation();
-
-            subObjectSelector.Deselect();
-			featureSelector.Deselect();
+			Deselected.Invoke();
 		}
 
 		private void OnDestroy()
@@ -400,14 +398,14 @@ namespace Netherlands3D.Twin.Interface.BAG
 		#endregion
 
 		#region UGUI methods
-		private void ShowObjectInformation()
+		public void ShowObjectInformation()
 		{
 			buildingContentPanel.SetActive(true);
 			placeholderPanel.SetActive(false);
 			featureContentPanel.SetActive(false);		
 		}
 
-		private void HideObjectInformation()
+		public void HideObjectInformation()
 		{
 			buildingContentPanel.SetActive(false);
 			placeholderPanel.SetActive(true);
@@ -415,14 +413,14 @@ namespace Netherlands3D.Twin.Interface.BAG
 			ClearLines();
 		}
 
-		private void ShowFeatureInformation()
+		public void ShowFeatureInformation()
 		{
             buildingContentPanel.SetActive(false);
             placeholderPanel.SetActive(false);
             featureContentPanel.SetActive(true);			
         }
 
-		private void HideFeatureInformation()
+		public void HideFeatureInformation()
 		{
             buildingContentPanel.SetActive(false);
             placeholderPanel.SetActive(true);

--- a/Assets/_Functionalities/ObjectInformation/Scripts/BagInspector.cs
+++ b/Assets/_Functionalities/ObjectInformation/Scripts/BagInspector.cs
@@ -81,8 +81,6 @@ namespace Netherlands3D.Twin.Interface.BAG
 			featureSelector = GetComponent<FeatureSelector>();
 
 			keyValuePairTemplate.gameObject.SetActive(false);
-
-			HideObjectInformation();
 		}
 
 		private void Update()


### PR DESCRIPTION
In this change, we add a new section to the object information sidebar that will display the additional information from the ATM people. The information is either their own based on an adamlink uri (as is present in the GeoJSON points) or our own based on the Bag id when you select a building