### PR TITLE
GeoJSON visualizations now initialize the style using the default

### DIFF
--- a/Assets/Scripts/Layers/LayerTypes/GeoJSONLineLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/GeoJSONLineLayer.cs
@@ -107,9 +107,14 @@ namespace Netherlands3D.Twin.Layers
             SpawnedVisualisations.Add(newFeatureVisualisation);
         }
 
-        public void ApplyStyling()
+        public override void InitializeStyling()
         {
             lineRenderer3D.LineMaterial = GetMaterialInstance();
+        }
+
+        public void ApplyStyling()
+        {
+            // Currently we don't apply individual styling per feature
         }
         
         private Material GetMaterialInstance()

--- a/Assets/Scripts/Layers/LayerTypes/GeoJSONPointLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/GeoJSONPointLayer.cs
@@ -91,7 +91,6 @@ namespace Netherlands3D.Twin.Layers
                 return;
 
             var newFeatureVisualisation = new FeaturePointVisualisations { feature = feature };
-
             ApplyStyling();
 
             if (feature.Geometry is MultiPoint multiPoint)
@@ -109,10 +108,14 @@ namespace Netherlands3D.Twin.Layers
             spawnedVisualisationDictionary.Add(feature.GetHashCode(), newFeatureVisualisation);
         }
 
+        public override void InitializeStyling()
+        {
+            pointRenderer3D.Material = GetMaterialInstance();
+        }
+
         public void ApplyStyling()
         {
-            if (!pointRenderer3D.Material)
-                pointRenderer3D.Material = GetMaterialInstance();
+            // Currently we don't apply individual styling per feature
         }
 
         private Material GetMaterialInstance()

--- a/Assets/Scripts/Layers/LayerTypes/GeoJSONPolygonLayer.cs
+++ b/Assets/Scripts/Layers/LayerTypes/GeoJSONPolygonLayer.cs
@@ -157,7 +157,7 @@ namespace Netherlands3D.Twin.Layers
             newFeatureVisualisation.ShowVisualisations(LayerData.ActiveInHierarchy);
         }
 
-        public void ApplyStyling()
+        public override void InitializeStyling()
         {
             foreach (var visualisations in SpawnedVisualisations)
             {

--- a/Assets/Scripts/Layers/LayerTypes/GeoJsonLayerGameObject.cs
+++ b/Assets/Scripts/Layers/LayerTypes/GeoJsonLayerGameObject.cs
@@ -220,7 +220,6 @@ namespace Netherlands3D.Twin.Layers
             // Replace default style with the parent's default style
             newPolygonLayerGameObject.LayerData.RemoveStyle(newPolygonLayerGameObject.LayerData.DefaultStyle);
             newPolygonLayerGameObject.LayerData.AddStyle(LayerData.DefaultStyle);
-            newPolygonLayerGameObject.ApplyStyling();
 
             newPolygonLayerGameObject.LayerData.SetParent(LayerData);
             
@@ -244,7 +243,6 @@ namespace Netherlands3D.Twin.Layers
             // Replace default style with the parent's default style
             newLineLayerGameObject.LayerData.RemoveStyle(newLineLayerGameObject.LayerData.DefaultStyle);
             newLineLayerGameObject.LayerData.AddStyle(LayerData.DefaultStyle);
-            newLineLayerGameObject.ApplyStyling();
 
             newLineLayerGameObject.LayerData.SetParent(LayerData);
             return newLineLayerGameObject;
@@ -267,7 +265,6 @@ namespace Netherlands3D.Twin.Layers
             // Replace default style with the parent's default style
             newPointLayerGameObject.LayerData.RemoveStyle(newPointLayerGameObject.LayerData.DefaultStyle);
             newPointLayerGameObject.LayerData.AddStyle(LayerData.DefaultStyle);
-            newPointLayerGameObject.ApplyStyling();
 
             newPointLayerGameObject.LayerData.SetParent(LayerData);
 

--- a/Assets/Scripts/Layers/LayerTypes/LayerGameObject.cs
+++ b/Assets/Scripts/Layers/LayerTypes/LayerGameObject.cs
@@ -27,7 +27,7 @@ namespace Netherlands3D.Twin.Layers
             {
                 if (layerData == null)
                 {
-                    Debug.Log("ReferencedProxy is null, creating new layer");
+                    // Debug.Log("ReferencedProxy is null, creating new layer");
                     CreateProxy();
                 }
                     
@@ -43,8 +43,7 @@ namespace Netherlands3D.Twin.Layers
                 }
             }
         }
-
-
+        
         [Space] 
         public UnityEvent onShow = new();
         public UnityEvent onHide = new();
@@ -71,6 +70,8 @@ namespace Netherlands3D.Twin.Layers
                 CreateProxy();
 
             OnLayerActiveInHierarchyChanged(LayerData.ActiveInHierarchy); //initialize the visualizations with the correct visibility
+
+            InitializeStyling();
         }
         
         private void CreateProxy()
@@ -124,6 +125,11 @@ namespace Netherlands3D.Twin.Layers
         public virtual void OnLayerActiveInHierarchyChanged(bool isActive)
         {
             //called when the Proxy's active state changes.          
+        }
+
+        public virtual void InitializeStyling()
+        {
+            //initialize the layer's style        
         }
     }
 }


### PR DESCRIPTION
Individual feature styles can be set, but currently aren't (no change with what already was the case).
This reduces the amount of styling calls that have to be done if the entire layer uses the default style. 