### PR TITLE
Bugfix/selecteren van polygonen hotfix van object informatie tonen

### DIFF
--- a/Assets/Prefabs/OpticalRaycaster.prefab
+++ b/Assets/Prefabs/OpticalRaycaster.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 1811041811788367721}
   - component: {fileID: 6667151011380368307}
   - component: {fileID: 7073721482847640295}
+  - component: {fileID: 4123874669779357784}
   m_Layer: 0
   m_Name: OpticalRaycaster
   m_TagString: Untagged
@@ -123,12 +124,12 @@ MonoBehaviour:
   m_RequiresColorTexture: 0
   m_Version: 2
   m_TaaSettings:
-    quality: 3
-    frameInfluence: 0.1
-    jitterScale: 1
-    mipBias: 0
-    varianceClampScale: 0.9
-    contrastAdaptiveSharpening: 0
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
 --- !u!114 &7073721482847640295
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -145,3 +146,15 @@ MonoBehaviour:
   OnDepthSampled:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &4123874669779357784
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5830911274202297391}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa0ac9a7cb99d4277a6e2c306626dfbf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/Layers/PolygonSelectionCalculator.cs
+++ b/Assets/Scripts/Layers/PolygonSelectionCalculator.cs
@@ -58,7 +58,7 @@ namespace Netherlands3D.Twin
 
             var camera = Camera.main;
             Plane[] frustumPlanes = GeometryUtility.CalculateFrustumPlanes(camera);
-            var worldPoint = opticalRaycaster.GetWorldPointAtCameraScreenPoint(camera, Pointer.current.position.ReadValue());
+            var worldPoint = opticalRaycaster.WorldPoint;
 
             foreach (var layer in Layers)
             {

--- a/Assets/Scripts/Layers/PolygonSelectionCalculator.cs
+++ b/Assets/Scripts/Layers/PolygonSelectionCalculator.cs
@@ -12,12 +12,12 @@ namespace Netherlands3D.Twin
     public class PolygonSelectionCalculator : MonoBehaviour
     {
         public static List<PolygonSelectionLayer> Layers = new();
-        private OpticalRaycaster opticalRaycaster;
+        private PointerToWorldPosition pointerToWorldPosition;
         private static bool polygonAddedThisFrame;
 
         private void Awake()
         {
-            opticalRaycaster = FindAnyObjectByType<OpticalRaycaster>();
+            pointerToWorldPosition = FindAnyObjectByType<PointerToWorldPosition>();
         }
 
         private void OnEnable()
@@ -58,7 +58,7 @@ namespace Netherlands3D.Twin
 
             var camera = Camera.main;
             Plane[] frustumPlanes = GeometryUtility.CalculateFrustumPlanes(camera);
-            var worldPoint = opticalRaycaster.WorldPoint;
+            var worldPoint = pointerToWorldPosition.WorldPoint;
 
             foreach (var layer in Layers)
             {

--- a/Assets/Scripts/Samplers/OpticalRaycaster.cs
+++ b/Assets/Scripts/Samplers/OpticalRaycaster.cs
@@ -1,37 +1,44 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
+using UnityEngine.InputSystem;
 
 namespace Netherlands3D.Twin
 {
     [RequireComponent(typeof(Camera))]
     public class OpticalRaycaster : MonoBehaviour
-    { 
+    {
         [SerializeField] private Camera depthCamera;
         float totalDepth = 0;
         private Texture2D samplerTexture;
-        
-        [Header("Events")]
-        [SerializeField] public UnityEvent<Vector3> OnDepthSampled;
+
+        [Header("Events")] [SerializeField] public UnityEvent<Vector3> OnDepthSampled;
+
+        public Vector3 WorldPoint { get; private set; } //Constantly updated world point
 
         void Start()
         {
-            if(depthCamera.targetTexture == null)
+            if (depthCamera.targetTexture == null)
             {
-                Debug.Log("Depth camera has no target texture. Please assign a render texture to the depth camera.",this.gameObject);
+                Debug.Log("Depth camera has no target texture. Please assign a render texture to the depth camera.", this.gameObject);
                 this.enabled = false;
                 return;
             }
 
             //We will only render on demand using camera.Render()
-            depthCamera.enabled = false; 
+            depthCamera.enabled = false;
 
             //Create a red channel texture that we can sample depth from
             samplerTexture = new Texture2D(depthCamera.targetTexture.width, depthCamera.targetTexture.height, TextureFormat.RGBAFloat, false);
         }
 
-        private void OnDestroy() {
+        private void Update()
+        {
+            var screenPoint = Pointer.current.position.ReadValue();
+            WorldPoint = GetWorldPointAtCameraScreenPoint(Camera.main, screenPoint);
+        }
+
+        private void OnDestroy()
+        {
             Destroy(samplerTexture);
         }
 
@@ -45,7 +52,7 @@ namespace Netherlands3D.Twin
         {
             AlignDepthCameraToScreenPoint(camera, screenPoint);
             RenderDepthCamera();
-            
+
             return GetDepthCameraWorldPoint();
         }
 
@@ -90,11 +97,11 @@ namespace Netherlands3D.Twin
 
         private Vector3 ReadWorldPositionFromPixel()
         {
-            var worldPosition = samplerTexture.GetPixel(0,0);
-            
+            var worldPosition = samplerTexture.GetPixel(0, 0);
+
             return new Vector3(
-                worldPosition.r, 
-                worldPosition.g, 
+                worldPosition.r,
+                worldPosition.g,
                 worldPosition.b
             );
         }

--- a/Assets/Scripts/Samplers/OpticalRaycaster.cs
+++ b/Assets/Scripts/Samplers/OpticalRaycaster.cs
@@ -1,6 +1,5 @@
 using UnityEngine;
 using UnityEngine.Events;
-using UnityEngine.InputSystem;
 
 namespace Netherlands3D.Twin
 {
@@ -12,9 +11,7 @@ namespace Netherlands3D.Twin
         private Texture2D samplerTexture;
 
         [Header("Events")] [SerializeField] public UnityEvent<Vector3> OnDepthSampled;
-
-        public Vector3 WorldPoint { get; private set; } //Constantly updated world point
-
+        
         void Start()
         {
             if (depthCamera.targetTexture == null)
@@ -29,12 +26,6 @@ namespace Netherlands3D.Twin
 
             //Create a red channel texture that we can sample depth from
             samplerTexture = new Texture2D(depthCamera.targetTexture.width, depthCamera.targetTexture.height, TextureFormat.RGBAFloat, false);
-        }
-
-        private void Update()
-        {
-            var screenPoint = Pointer.current.position.ReadValue();
-            WorldPoint = GetWorldPointAtCameraScreenPoint(Camera.main, screenPoint);
         }
 
         private void OnDestroy()

--- a/Assets/Scripts/Samplers/PointerToWorldPosition.cs
+++ b/Assets/Scripts/Samplers/PointerToWorldPosition.cs
@@ -1,0 +1,22 @@
+using UnityEngine.InputSystem;
+using UnityEngine;
+
+namespace Netherlands3D.Twin
+{
+    public class PointerToWorldPosition : MonoBehaviour
+    {
+        public Vector3 WorldPoint { get; private set; } //Constantly updated world point
+        private OpticalRaycaster opticalRaycaster;
+
+        private void Awake()
+        {
+            opticalRaycaster = GetComponent<OpticalRaycaster>();
+        }
+
+        private void Update()
+        {
+            var screenPoint = Pointer.current.position.ReadValue();
+            WorldPoint = opticalRaycaster.GetWorldPointAtCameraScreenPoint(Camera.main, screenPoint);
+        }
+    }
+}

--- a/Assets/Scripts/Samplers/PointerToWorldPosition.cs.meta
+++ b/Assets/Scripts/Samplers/PointerToWorldPosition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa0ac9a7cb99d4277a6e2c306626dfbf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Selection/PolygonInputWithOpticalRaycastHeight.cs
+++ b/Assets/Scripts/Selection/PolygonInputWithOpticalRaycastHeight.cs
@@ -17,8 +17,7 @@ namespace Netherlands3D.Twin
 
         protected override void UpdateCurrentWorldCoordinate()
         {
-            var currentPointerPosition = pointerAction.ReadValue<Vector2>();
-            var point = opticalRaycaster.GetWorldPointAtCameraScreenPoint(Camera.main, currentPointerPosition);
+            var point = opticalRaycaster.WorldPoint;
 
             if (point != Vector3.zero)
                 currentWorldCoordinate = point;

--- a/Assets/Scripts/Selection/PolygonInputWithOpticalRaycastHeight.cs
+++ b/Assets/Scripts/Selection/PolygonInputWithOpticalRaycastHeight.cs
@@ -7,17 +7,17 @@ namespace Netherlands3D.Twin
 {
     public class PolygonInputWithOpticalRaycastHeight : PolygonInput
     {
-        private OpticalRaycaster opticalRaycaster;
+        private PointerToWorldPosition pointerToWorldPosition;
 
         protected override void Awake()
         {
             base.Awake();
-            opticalRaycaster = GameObject.FindAnyObjectByType<OpticalRaycaster>();
+            pointerToWorldPosition = GameObject.FindAnyObjectByType<PointerToWorldPosition>();
         }
 
         protected override void UpdateCurrentWorldCoordinate()
         {
-            var point = opticalRaycaster.WorldPoint;
+            var point = pointerToWorldPosition.WorldPoint;
 
             if (point != Vector3.zero)
                 currentWorldCoordinate = point;

--- a/Assets/_Functionalities/ObjectInformation/Scripts/BagInspector.cs
+++ b/Assets/_Functionalities/ObjectInformation/Scripts/BagInspector.cs
@@ -404,6 +404,8 @@ namespace Netherlands3D.Twin.Interface.BAG
 			Dictionary<string, object> properties = mapping.Feature.Properties as Dictionary<string, object>;
 			foreach (KeyValuePair<string, object> property in properties)
 			{
+				if(property.Value == null) continue;
+
 				SpawnKeyValue(property.Key, property.Value.ToString());
 			}
 		}

--- a/Assets/_Functionalities/ObjectInformation/Scripts/FeatureSelector.cs
+++ b/Assets/_Functionalities/ObjectInformation/Scripts/FeatureSelector.cs
@@ -38,12 +38,12 @@ namespace Netherlands3D.Twin.ObjectInformation
         private ObjectMapping blockingObjectMapping;
         private Vector3 blockingObjectMappingHitPoint;
 
-        private OpticalRaycaster opticalRaycaster;
+        private PointerToWorldPosition pointerToWorldPosition;
 
         private void Awake()
         {
             mainCamera = Camera.main;
-            opticalRaycaster = FindAnyObjectByType<OpticalRaycaster>();
+            pointerToWorldPosition = FindAnyObjectByType<PointerToWorldPosition>();
         }
 
         public void Select(FeatureMapping mapping)
@@ -72,7 +72,7 @@ namespace Netherlands3D.Twin.ObjectInformation
         public void FindFeature(Ray ray)
         {
             Plane[] frustumPlanes = GeometryUtility.CalculateFrustumPlanes(mainCamera);
-            Vector3 groundPosition = opticalRaycaster.WorldPoint;
+            Vector3 groundPosition = pointerToWorldPosition.WorldPoint;
             featureMappings.Clear();
             if (blockingObjectMapping != null)
             {

--- a/Assets/_Functionalities/ObjectInformation/Scripts/FeatureSelector.cs
+++ b/Assets/_Functionalities/ObjectInformation/Scripts/FeatureSelector.cs
@@ -72,8 +72,7 @@ namespace Netherlands3D.Twin.ObjectInformation
         public void FindFeature(Ray ray)
         {
             Plane[] frustumPlanes = GeometryUtility.CalculateFrustumPlanes(mainCamera);
-            var worldPoint = opticalRaycaster.GetWorldPointAtCameraScreenPoint(mainCamera, Pointer.current.position.ReadValue());
-            Vector3 groundPosition = worldPoint;
+            Vector3 groundPosition = opticalRaycaster.WorldPoint;
             featureMappings.Clear();
             if (blockingObjectMapping != null)
             {


### PR DESCRIPTION
Polygons can now be selected again.
Added convenience property to optical raycaster which will also reduce the amount of calls to the optical raycaster.

https://cdn-dev-ams-3da.azureedge.net/autobuild/bugfix/selecteren-van-polygonen-hotfix-van-object-informatie-tonen/115640774/