### PR TITLE
Updated the UI Ticker

### DIFF
--- a/Assets/Prefabs/UI/Layers/LayerUI.prefab
+++ b/Assets/Prefabs/UI/Layers/LayerUI.prefab
@@ -808,6 +808,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   childRect: {fileID: 7499595349914018578}
   scrollSpeed: 50
+  childWidth: 0
+  parentWidth: 0
 --- !u!114 &4629240257727574136
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -990,11 +992,19 @@ MonoBehaviour:
   m_CharacterLimit: 0
   m_OnEndEdit:
     m_PersistentCalls:
-      m_Calls: [{m_Target: {fileID: 4633896996343027297}, m_TargetAssemblyTypeName: 'Netherlands3D.Twin.TextTicker,
-            Assembly-CSharp', m_MethodName: OnWidthChange, m_Mode: 1, m_Arguments: {
-            m_ObjectArgument: {fileID: 0}, m_ObjectArgumentAssemblyTypeName: 'UnityEngine.Object,
-              UnityEngine', m_IntArgument: 0, m_FloatArgument: 0, m_StringArgument: '',
-            m_BoolArgument: 0}, m_CallState: 2}]
+      m_Calls:
+      - m_Target: {fileID: 4633896996343027297}
+        m_TargetAssemblyTypeName: Netherlands3D.Twin.TextTicker, Assembly-CSharp
+        m_MethodName: OnWidthChange
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_OnSubmit:
     m_PersistentCalls:
       m_Calls: []
@@ -2093,6 +2103,7 @@ GameObject:
   - component: {fileID: 2127760596796970168}
   - component: {fileID: 1244387766270603908}
   - component: {fileID: 2493342414096201978}
+  - component: {fileID: 755085454250548177}
   m_Layer: 5
   m_Name: LayerUI
   m_TagString: Untagged
@@ -2206,6 +2217,51 @@ MonoBehaviour:
   layerTypeImage: {fileID: 1356745287749164724}
   errorLayerTypeImage: {fileID: 94072058954664853}
   errorColor: {r: 0.8, g: 0.84313726, b: 0.89411765, a: 1}
+--- !u!114 &755085454250548177
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6053239577656790416}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 0
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 4633896996343027297}
+          m_TargetAssemblyTypeName: Netherlands3D.Twin.TextTicker, Assembly-CSharp
+          m_MethodName: CheckAndStartScrolling
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - eventID: 1
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 4633896996343027297}
+          m_TargetAssemblyTypeName: Netherlands3D.Twin.TextTicker, Assembly-CSharp
+          m_MethodName: StopScrolling
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!1 &6171282763605231320
 GameObject:
   m_ObjectHideFlags: 0
@@ -2566,11 +2622,19 @@ MonoBehaviour:
   m_Group: {fileID: 0}
   onValueChanged:
     m_PersistentCalls:
-      m_Calls: [{m_Target: {fileID: 1850104207184435544}, m_TargetAssemblyTypeName: 'UnityEngine.UI.Toggle,
-            UnityEngine.UI', m_MethodName: set_isOn, m_Mode: 0, m_Arguments: {m_ObjectArgument: {
-              fileID: 0}, m_ObjectArgumentAssemblyTypeName: 'UnityEngine.Object, UnityEngine',
-            m_IntArgument: 0, m_FloatArgument: 0, m_StringArgument: '', m_BoolArgument: 0},
-          m_CallState: 2}]
+      m_Calls:
+      - m_Target: {fileID: 1850104207184435544}
+        m_TargetAssemblyTypeName: UnityEngine.UI.Toggle, UnityEngine.UI
+        m_MethodName: set_isOn
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_IsOn: 1
 --- !u!1 &7119179143932802346
 GameObject:

--- a/Assets/Scripts/UI/Components/TextTicker.cs
+++ b/Assets/Scripts/UI/Components/TextTicker.cs
@@ -11,8 +11,8 @@ namespace Netherlands3D.Twin
         public float scrollSpeed = 200f; // Speed of scrolling
 
         private RectTransform parentRect;
-        public float childWidth;
-        public float parentWidth;
+        private float childWidth;
+        private float parentWidth;
         private Coroutine scrollingCoroutine;
 
         void Awake()

--- a/Assets/Scripts/UI/Components/TextTicker.cs
+++ b/Assets/Scripts/UI/Components/TextTicker.cs
@@ -11,8 +11,8 @@ namespace Netherlands3D.Twin
         public float scrollSpeed = 200f; // Speed of scrolling
 
         private RectTransform parentRect;
-        private float childWidth;
-        private float parentWidth;
+        public float childWidth;
+        public float parentWidth;
         private Coroutine scrollingCoroutine;
 
         void Awake()
@@ -22,45 +22,27 @@ namespace Netherlands3D.Twin
 
         void Start()
         {
-            // Get initial widths and set initial position  
-            UpdateWidths();
             SetInitialPosition();
-
-            // You can call this method to start monitoring for width changes  
-            StartMonitoringWidth();
         }
 
         private void SetInitialPosition()
         {
+            childWidth = childRect.rect.width;
+            parentWidth = parentRect.rect.width;
+
             if (childWidth > parentWidth)
             {
                 childRect.anchoredPosition = new Vector2(0, childRect.anchoredPosition.y);
             }
         }
 
-        private void UpdateWidths()
+  
+
+        public void CheckAndStartScrolling()
         {
-            // Get widths of parent and child RectTransforms  
             childWidth = childRect.rect.width;
             parentWidth = parentRect.rect.width;
-        }
 
-        // Start monitoring for width changes  
-        public void StartMonitoringWidth()
-        {
-            UpdateWidths(); // Initial check 
-            CheckAndStartScrolling(); // Check and start scrolling if necessary  
-        }
-
-        // Example event trigger method to be called when needed  
-        public void OnWidthChange() // Call this method when a width change occurs  
-        {
-            Invoke("UpdateWidths",0.1f);
-            Invoke("CheckAndStartScrolling",0.1f);
-        }
-
-        private void CheckAndStartScrolling()
-        {
             if (childWidth > parentWidth)
             {
                 if (scrollingCoroutine == null)
@@ -78,6 +60,7 @@ namespace Netherlands3D.Twin
         {
             while (true)
             {
+
                 Vector2 newPosition = childRect.anchoredPosition;
                 newPosition.x -= scrollSpeed * Time.deltaTime;
 
@@ -93,7 +76,7 @@ namespace Netherlands3D.Twin
             }
         }
 
-        private void StopScrolling()
+        public void StopScrolling()
         {
             if (scrollingCoroutine != null)
             {


### PR DESCRIPTION
UI ticker now only triggers when the mouse is over the selected text. The child objects don't automatically tick any longer. however, when the mouse is over a child with a text that is long enough to 'tick', it also triggers its parent's ticker IF the parent's text is also long enough to 'tick'.