### PR TITLE
setting a layer to a parent in its descendants now fails to avoid a cyclic reference

### DIFF
--- a/Assets/Scripts/Layers/LayerTypes/LayerData.cs
+++ b/Assets/Scripts/Layers/LayerTypes/LayerData.cs
@@ -226,7 +226,10 @@ namespace Netherlands3D.Twin.Layers
             if (newParent == null)
                 newParent = Root;
 
-            if (newParent == this)
+            //in two cases we should not Set a new parent, since it would create a cyclical reference:
+            //1. if you are trying to parent a layer to itself
+            //2. if this LayerData is somewhere in the parent chain of the new parent.
+            if (newParent == this || IsParentOrAncestor(newParent))
                 return;
             
             var parentChanged = ParentLayer != newParent;
@@ -264,6 +267,22 @@ namespace Netherlands3D.Twin.Layers
                 ParentChanged.Invoke();
                 newParent.ChildrenChanged.Invoke(); //call event on new parent
             }
+        }
+        
+        //This function checks if this LayerData is somewhere in the parent chain of the layerToCheck
+        private bool IsParentOrAncestor(LayerData layerToCheck)
+        {
+            var current = layerToCheck;
+            while (current != null)
+            {
+                if (current == this)
+                {
+                    return true;
+                }
+
+                current = current.ParentLayer;
+            }
+            return false;
         }
 
         public virtual void DestroyLayer()


### PR DESCRIPTION
https://cdn-dev-ams-3da.azureedge.net/autobuild/bugfix/set-parent-recursion/1361747456/