### PR TITLE
Additional namespace should only be loaded if the XML is missing them.

### DIFF
--- a/Assets/Scripts/Layers/Adapters/DataTypeAdapters/WFSGeoJSONImportAdapter.cs
+++ b/Assets/Scripts/Layers/Adapters/DataTypeAdapters/WFSGeoJSONImportAdapter.cs
@@ -358,8 +358,14 @@ namespace Netherlands3D.Twin
             {
                 XmlNamespaceManager namespaceManager = new(xmlDocument.NameTable);
                 XmlNodeList elementsWithNamespaces = xmlDocument.SelectNodes("//*");
-                namespaceManager.AddNamespace("wfs", "http://www.opengis.net/wfs");
-                namespaceManager.AddNamespace("ows", "http://www.opengis.net/ows");
+                if (namespaceManager.HasNamespace("wfs") == false)
+                {
+                    namespaceManager.AddNamespace("wfs", "http://www.opengis.net/wfs");
+                }
+                if (namespaceManager.HasNamespace("ows") == false)
+                {
+                    namespaceManager.AddNamespace("ows", "http://www.opengis.net/ows/1.1");
+                }
 
                 if (elementsWithNamespaces != null)
                 {


### PR DESCRIPTION
The XML file should define all namespaces that you need, but we do checks on XML files using namespaces unknown to that file (such as OWS checks on a GetFeature action). In these instances we need to supplement the namespacemanager because the XML scheme doesn't -correctly- define them.

BUT: if you define a namespace with a URL that is different from the one defined in the XML file, then it will stop working correctly and refuse to load the XML file and/or apply XPath queries correctly