### PR TITLE
bugfix default crs / srs

### DIFF
--- a/Assets/Scripts/Layers/Adapters/DataTypeAdapters/WFSGeoJSONImportAdapter.cs
+++ b/Assets/Scripts/Layers/Adapters/DataTypeAdapters/WFSGeoJSONImportAdapter.cs
@@ -346,23 +346,18 @@ namespace Netherlands3D.Twin
                     {
                         continue;
                     }
-                    
+                    var crsNode = featureTypeNode.SelectSingleNode("wfs:DefaultSRS | wfs:DefaultCRS", namespaceManager);
+                    string crs = crsNode?.InnerText;
+
                     using (XmlNodeReader reader = new XmlNodeReader(featureTypeNode))
                     {
                         reader.MoveToContent(); // Move to the root element of the node
 
                         // Deserialize the FeatureType element while handling the namespaces properly
-
                         FeatureType featureType = serializer.Deserialize(reader) as FeatureType;
                         if (featureType == null) continue;
 
-                        // Handle CRS if it exists
-                        var crsNode = featureTypeNode.SelectSingleNode("//*[local-name()='DefaultCRS']");
-                        if (crsNode != null)
-                        {
-                            string crs = crsNode.InnerText;
-                        }
-
+                        featureType.DefaultCRS = crs;
                         featureTypes.Add(featureType);
                     }
                 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -28,7 +28,7 @@
     "eu.netherlands3d.minimap": "1.1.6",
     "eu.netherlands3d.obj-importer": "1.2.2",
     "eu.netherlands3d.periodic-snapshots": "2.0.0",
-    "eu.netherlands3d.selection-tools": "2.6.0",
+    "eu.netherlands3d.selection-tools": "2.6.1",
     "eu.netherlands3d.simplejson": "1.0.0",
     "eu.netherlands3d.snapshots": "2.0.0",
     "eu.netherlands3d.subobjects": "1.3.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -380,7 +380,7 @@
       "url": "https://package.openupm.com"
     },
     "eu.netherlands3d.selection-tools": {
-      "version": "2.6.0",
+      "version": "2.6.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
-now properly extracting the default srs/crs from the featuretypenode.
-updated package selectiontools with release because there was an error creating the polygons (setuvcoordinate)

https://cdn-dev-ams-3da.azureedge.net/autobuild/bugfix/inhoud-tygron-wfs-lagen-worden-niet-getoond/1040980005/