### PR TITLE
Due to inheritance, an extra invalid request was done

### DIFF
--- a/Assets/_Application/Layers/LayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerGameObject.cs
@@ -68,7 +68,7 @@ namespace Netherlands3D.Twin.Layers
             InitializeVisualisation();
         }
 
-        protected void InitializeVisualisation()
+        protected virtual void InitializeVisualisation()
         {
             if (LayerData == null) //if the layer data object was not initialized when creating this object, create a new LayerDataObject
                 CreateProxy();

--- a/Assets/_Application/Layers/LayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerGameObject.cs
@@ -65,6 +65,11 @@ namespace Netherlands3D.Twin.Layers
         
         protected virtual void Start()
         {
+            InitializeVisualisation();
+        }
+
+        protected void InitializeVisualisation()
+        {
             if (LayerData == null) //if the layer data object was not initialized when creating this object, create a new LayerDataObject
                 CreateProxy();
 
@@ -72,7 +77,7 @@ namespace Netherlands3D.Twin.Layers
 
             InitializeStyling();
         }
-        
+
         private void CreateProxy()
         {
             ProjectData.AddReferenceLayer(this);

--- a/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/GeoJsonLayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/GeoJsonLayerGameObject.cs
@@ -39,9 +39,9 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.GeoJsonLayers
             parser.OnFeatureParsed.AddListener(AddFeatureVisualisation);
         }
         
-        protected override void Start()
+        protected new void Start()
         {
-            base.Start();
+            InitializeVisualisation();
 
             if (urlPropertyData.Data.IsStoredInProject())
             {

--- a/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/GeoJsonLayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/GeoJsonLayerGameObject.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
@@ -39,10 +40,14 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.GeoJsonLayers
             parser.OnFeatureParsed.AddListener(AddFeatureVisualisation);
         }
         
-        protected new void Start()
+        protected override void Start()
         {
-            InitializeVisualisation();
+            base.Start();
+            StartLoadingData();
+        }
 
+        protected virtual void StartLoadingData()
+        {
             if (urlPropertyData.Data.IsStoredInProject())
             {
                 string path = Path.Combine(Application.persistentDataPath, urlPropertyData.Data.LocalPath.TrimStart('/', '\\'));

--- a/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/GeoJsonLayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/GeoJsonLayerGameObject.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Buffers.Text;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;

--- a/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/WFSGeoJSONLayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/WFSGeoJSONLayerGameObject.cs
@@ -18,9 +18,8 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.GeoJsonLayers
             CartesianTileWFSLayer.WFSGeoJSONLayer = this;
         }
 
-        protected new void Start()
+        protected override void StartLoadingData()
         {
-            InitializeVisualisation();
             cartesianTileWFSLayer.WfsUrl = urlPropertyData.Data.ToString();
         }
 

--- a/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/WFSGeoJSONLayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/WFSGeoJSONLayerGameObject.cs
@@ -18,9 +18,9 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.GeoJsonLayers
             CartesianTileWFSLayer.WFSGeoJSONLayer = this;
         }
 
-        protected override void Start()
+        protected new void Start()
         {
-            base.Start();
+            InitializeVisualisation();
             cartesianTileWFSLayer.WfsUrl = urlPropertyData.Data.ToString();
         }
 


### PR DESCRIPTION
The GeoJsonLayerGameObject class is the base class for our Wfs implementation; but the WFS loads geometric information in the tile handling instead of the gameobject directly.

This caused an extra request -because the GeoJSON flow does it in start- with an invalid parameter, triggering an auth flow in Tygron and causing subssequent requests to be blocked.

By changing the way LayerGameObject initializes, and by doing layer initialization using composition instead of inheritance, we can avoid the extra request and thus the issue