### PR TITLE
performance update opticalraycaster

### DIFF
--- a/Assets/Prefabs/OpticalRaycaster.prefab
+++ b/Assets/Prefabs/OpticalRaycaster.prefab
@@ -9,8 +9,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 669998098775430263}
-  - component: {fileID: 1811041811788367721}
-  - component: {fileID: 6667151011380368307}
   - component: {fileID: 7073721482847640295}
   - component: {fileID: 4123874669779357784}
   m_Layer: 0
@@ -35,101 +33,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!20 &1811041811788367721
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5830911274202297391}
-  m_Enabled: 0
-  serializedVersion: 2
-  m_ClearFlags: 2
-  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_Iso: 200
-  m_ShutterSpeed: 0.005
-  m_Aperture: 16
-  m_FocusDistance: 10
-  m_FocalLength: 50
-  m_BladeCount: 5
-  m_Curvature: {x: 2, y: 11}
-  m_BarrelClipping: 0.25
-  m_Anamorphism: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 10000
-  field of view: 60
-  orthographic: 1
-  orthographic size: 1
-  m_Depth: -1
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 192
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 8400000, guid: e4924a2b6411f0b4ca70f6fdf09c5f93, type: 2}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!114 &6667151011380368307
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5830911274202297391}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_RenderShadows: 0
-  m_RequiresDepthTextureOption: 2
-  m_RequiresOpaqueTextureOption: 2
-  m_CameraType: 0
-  m_Cameras: []
-  m_RendererIndex: 4
-  m_VolumeLayerMask:
-    serializedVersion: 2
-    m_Bits: 1
-  m_VolumeTrigger: {fileID: 0}
-  m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
-  m_Antialiasing: 0
-  m_AntialiasingQuality: 2
-  m_StopNaN: 0
-  m_Dithering: 0
-  m_ClearDepth: 1
-  m_AllowXRRendering: 1
-  m_AllowHDROutput: 1
-  m_UseScreenCoordOverride: 0
-  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
-  m_RequiresDepthTexture: 0
-  m_RequiresColorTexture: 0
-  m_Version: 2
-  m_TaaSettings:
-    m_Quality: 3
-    m_FrameInfluence: 0.1
-    m_JitterScale: 1
-    m_MipBias: 0
-    m_VarianceClampScale: 0.9
-    m_ContrastAdaptiveSharpening: 0
 --- !u!114 &7073721482847640295
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -142,10 +45,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6b28267e61a547643a0f7f83319d6cca, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  depthCamera: {fileID: 1811041811788367721}
-  OnDepthSampled:
-    m_PersistentCalls:
-      m_Calls: []
+  depthCameraPrefab: {fileID: 1509221224025641588, guid: a878597ab40688f4a880932399e381ec,
+    type: 3}
+  depthToWorldMaterial: {fileID: 2100000, guid: 5f4b4770e3b06a141aaed4641eeac46b,
+    type: 2}
+  visualizationMaterial: {fileID: 2100000, guid: 6986404031f7a3147b16a3526abf03c1,
+    type: 2}
 --- !u!114 &4123874669779357784
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Rendering/DepthTexture.renderTexture
+++ b/Assets/Rendering/DepthTexture.renderTexture
@@ -26,7 +26,7 @@ RenderTexture:
   m_UseDynamicScale: 0
   m_BindMS: 0
   m_EnableCompatibleFormat: 1
-  m_EnableRandomWrite: 0
+  m_EnableRandomWrite: 1
   m_TextureSettings:
     serializedVersion: 2
     m_FilterMode: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -757,42 +757,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1811041811788367721, guid: ee361773856b5e0419afdbf630604742,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 5830911274202297391, guid: ee361773856b5e0419afdbf630604742,
         type: 3}
       propertyPath: m_Name
       value: OpticalRaycaster
       objectReference: {fileID: 0}
-    - target: {fileID: 6667151011380368307, guid: ee361773856b5e0419afdbf630604742,
-        type: 3}
-      propertyPath: m_CameraType
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6667151011380368307, guid: ee361773856b5e0419afdbf630604742,
-        type: 3}
-      propertyPath: m_ClearDepth
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
-        type: 3}
-      propertyPath: depthCamera
-      value: 
-      objectReference: {fileID: 1509221224025641588, guid: a878597ab40688f4a880932399e381ec,
-        type: 3}
-    - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
-        type: 3}
-      propertyPath: depthMaterial
-      value: 
-      objectReference: {fileID: 2100000, guid: 5f4b4770e3b06a141aaed4641eeac46b, type: 2}
-    - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
-        type: 3}
-      propertyPath: sampleMaterial
-      value: 
-      objectReference: {fileID: 2100000, guid: 8041683e99730df4abd13966dddbff0a, type: 2}
     - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
         type: 3}
       propertyPath: depthCameraPrefab
@@ -809,24 +778,7 @@ PrefabInstance:
       propertyPath: visualizationMaterial
       value: 
       objectReference: {fileID: 2100000, guid: 6986404031f7a3147b16a3526abf03c1, type: 2}
-    - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
-        type: 3}
-      propertyPath: worldPosSampleMaterial
-      value: 
-      objectReference: {fileID: 2100000, guid: 8041683e99730df4abd13966dddbff0a, type: 2}
-    - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
-        type: 3}
-      propertyPath: OnDepthSampled.m_PersistentCalls.m_Calls.Array.size
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
-        type: 3}
-      propertyPath: OnDepthSampled.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 6667151011380368307, guid: ee361773856b5e0419afdbf630604742, type: 3}
-    - {fileID: 1811041811788367721, guid: ee361773856b5e0419afdbf630604742, type: 3}
+    m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -779,6 +779,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
         type: 3}
+      propertyPath: depthCamera
+      value: 
+      objectReference: {fileID: 1509221224025641588, guid: a878597ab40688f4a880932399e381ec,
+        type: 3}
+    - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
+        type: 3}
       propertyPath: depthMaterial
       value: 
       objectReference: {fileID: 2100000, guid: 5f4b4770e3b06a141aaed4641eeac46b, type: 2}
@@ -787,6 +793,22 @@ PrefabInstance:
       propertyPath: sampleMaterial
       value: 
       objectReference: {fileID: 2100000, guid: 8041683e99730df4abd13966dddbff0a, type: 2}
+    - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
+        type: 3}
+      propertyPath: depthCameraPrefab
+      value: 
+      objectReference: {fileID: 1509221224025641588, guid: a878597ab40688f4a880932399e381ec,
+        type: 3}
+    - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
+        type: 3}
+      propertyPath: depthToWorldMaterial
+      value: 
+      objectReference: {fileID: 2100000, guid: 5f4b4770e3b06a141aaed4641eeac46b, type: 2}
+    - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
+        type: 3}
+      propertyPath: visualizationMaterial
+      value: 
+      objectReference: {fileID: 2100000, guid: 6986404031f7a3147b16a3526abf03c1, type: 2}
     - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
         type: 3}
       propertyPath: worldPosSampleMaterial
@@ -802,7 +824,9 @@ PrefabInstance:
       propertyPath: OnDepthSampled.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6667151011380368307, guid: ee361773856b5e0419afdbf630604742, type: 3}
+    - {fileID: 1811041811788367721, guid: ee361773856b5e0419afdbf630604742, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -757,11 +757,41 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1811041811788367721, guid: ee361773856b5e0419afdbf630604742,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 5830911274202297391, guid: ee361773856b5e0419afdbf630604742,
         type: 3}
       propertyPath: m_Name
       value: OpticalRaycaster
       objectReference: {fileID: 0}
+    - target: {fileID: 6667151011380368307, guid: ee361773856b5e0419afdbf630604742,
+        type: 3}
+      propertyPath: m_CameraType
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6667151011380368307, guid: ee361773856b5e0419afdbf630604742,
+        type: 3}
+      propertyPath: m_ClearDepth
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
+        type: 3}
+      propertyPath: depthMaterial
+      value: 
+      objectReference: {fileID: 2100000, guid: 5f4b4770e3b06a141aaed4641eeac46b, type: 2}
+    - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
+        type: 3}
+      propertyPath: sampleMaterial
+      value: 
+      objectReference: {fileID: 2100000, guid: 8041683e99730df4abd13966dddbff0a, type: 2}
+    - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
+        type: 3}
+      propertyPath: worldPosSampleMaterial
+      value: 
+      objectReference: {fileID: 2100000, guid: 8041683e99730df4abd13966dddbff0a, type: 2}
     - target: {fileID: 7073721482847640295, guid: ee361773856b5e0419afdbf630604742,
         type: 3}
       propertyPath: OnDepthSampled.m_PersistentCalls.m_Calls.Array.size

--- a/Assets/_Application/Prefabs/DepthCamera.prefab
+++ b/Assets/_Application/Prefabs/DepthCamera.prefab
@@ -1,0 +1,130 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6023607682745640888
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6968248212801022247}
+  - component: {fileID: 1509221224025641588}
+  - component: {fileID: 4680629798990586216}
+  m_Layer: 0
+  m_Name: DepthCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6968248212801022247
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6023607682745640888}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -318.59998, y: 74.9919, z: 680.51196}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &1509221224025641588
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6023607682745640888}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 10000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 1
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 192
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 8400000, guid: e4924a2b6411f0b4ca70f6fdf09c5f93, type: 2}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &4680629798990586216
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6023607682745640888}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0

--- a/Assets/_Application/Prefabs/DepthCamera.prefab
+++ b/Assets/_Application/Prefabs/DepthCamera.prefab
@@ -40,7 +40,7 @@ Camera:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6023607682745640888}
-  m_Enabled: 0
+  m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 2
   m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
@@ -80,7 +80,7 @@ Camera:
   m_HDR: 1
   m_AllowMSAA: 1
   m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
+  m_ForceIntoRT: 1
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
@@ -101,7 +101,7 @@ MonoBehaviour:
   m_RequiresOpaqueTextureOption: 2
   m_CameraType: 0
   m_Cameras: []
-  m_RendererIndex: -1
+  m_RendererIndex: 4
   m_VolumeLayerMask:
     serializedVersion: 2
     m_Bits: 1

--- a/Assets/_Application/Prefabs/DepthCamera.prefab.meta
+++ b/Assets/_Application/Prefabs/DepthCamera.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a878597ab40688f4a880932399e381ec
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Application/Samplers/DepthPositionMaterial.mat
+++ b/Assets/_Application/Samplers/DepthPositionMaterial.mat
@@ -1,0 +1,139 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: DepthPositionMaterial
+  m_Shader: {fileID: 4800000, guid: b02324e6281613a48907e5b20579e7bf, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 2000
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _CameraDepthTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _DepthColor: {r: 1, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _MyScreenParams: {r: 0.3, g: 8000, b: 0, a: 0}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _WorldPos: {r: 0, g: 0, b: 0, a: 0}
+  m_BuildTextureStacks: []
+--- !u!114 &8244243540393324956
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Assets/_Application/Samplers/DepthPositionMaterial.mat.meta
+++ b/Assets/_Application/Samplers/DepthPositionMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f4b4770e3b06a141aaed4641eeac46b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Application/Samplers/DepthShader.shader
+++ b/Assets/_Application/Samplers/DepthShader.shader
@@ -1,0 +1,79 @@
+Shader "Custom/WorldPositionFromDepth"
+{
+    Properties
+    {
+        _CameraDepthTexture("Camera Depth Texture", 2D) = "white" {}
+        _DepthColor("Depth Color", Color) = (0, 0, 0, 1)
+    }
+    SubShader
+    {
+        Tags { "RenderType" = "Opaque" }
+
+        Pass
+        {
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            TEXTURE2D(_CameraDepthTexture);
+            SAMPLER(sampler_CameraDepthTexture);
+
+            // Uniforms for inverse matrices (you will pass these from the script)
+            float4x4 _CameraInvViewProjection; // Inverse of the camera's ViewProjection matrix
+            float4 _MyScreenParams;            // Near and far planes (x = near, y = far)
+
+            // Global shader variable for DepthColor (updated in fragment shader)
+            float4 _DepthColor;
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            Varyings vert(Attributes v)
+            {
+                Varyings o;
+                o.positionCS = TransformObjectToHClip(v.positionOS);
+                o.uv = v.uv;
+                return o;
+            }
+
+            // Fragment Shader: Sample the depth and convert to world position
+            half4 frag(Varyings i) : SV_Target
+            {
+                // Sample depth from the depth texture at the current UV coordinates
+                float depth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, sampler_CameraDepthTexture, i.uv);
+
+                // Normalize depth to the range [0, 1] using the near and far planes
+                depth = LinearEyeDepth(depth, _MyScreenParams.x, _MyScreenParams.y);
+
+                // Convert depth to clip space
+                float4 clipSpace = float4(i.uv * 2.0 - 1.0, depth * 2.0 - 1.0, 1.0);
+
+                // Convert from clip space to world space
+                float4 worldPos = mul(_CameraInvViewProjection, clipSpace);
+                worldPos /= worldPos.w; // Perspective divide
+
+                // Return the world position in the RGB channels (for sampling)
+                return half4(worldPos.xyz, 1.0);
+            }
+
+            // Function to convert from non-linear depth to linear depth
+            float LinearEyeDepth(float depth, float near, float far)
+            {
+                // Converts the depth from non-linear to linear space
+                return near * far / (far - (far - near) * depth);
+            }
+
+            ENDHLSL
+        }
+    }
+}

--- a/Assets/_Application/Samplers/DepthShader.shader
+++ b/Assets/_Application/Samplers/DepthShader.shader
@@ -2,78 +2,68 @@ Shader "Custom/WorldPositionFromDepth"
 {
     Properties
     {
-        _CameraDepthTexture("Camera Depth Texture", 2D) = "white" {}
-        _DepthColor("Depth Color", Color) = (0, 0, 0, 1)
+        _CameraDepthTexture ("Depth Texture", 2D) = "white" { }
     }
     SubShader
     {
-        Tags { "RenderType" = "Opaque" }
-
+        Tags { "RenderType"="Opaque" }
         Pass
         {
-            HLSLPROGRAM
+            CGPROGRAM
             #pragma vertex vert
             #pragma fragment frag
-            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "UnityCG.cginc"
 
-            TEXTURE2D(_CameraDepthTexture);
-            SAMPLER(sampler_CameraDepthTexture);
-
-            // Uniforms for inverse matrices (you will pass these from the script)
-            float4x4 _CameraInvViewProjection; // Inverse of the camera's ViewProjection matrix
-            float4 _MyScreenParams;            // Near and far planes (x = near, y = far)
-
-            // Global shader variable for DepthColor (updated in fragment shader)
-            float4 _DepthColor;
-
-            struct Attributes
+            struct appdata
             {
-                float4 positionOS : POSITION;
+                float4 vertex : POSITION;
                 float2 uv : TEXCOORD0;
             };
 
-            struct Varyings
+            struct v2f
             {
-                float4 positionCS : SV_POSITION;
+                float4 pos : POSITION;
                 float2 uv : TEXCOORD0;
             };
 
-            Varyings vert(Attributes v)
+            sampler2D _CameraDepthTexture;
+            float4x4 _CameraInvProjection;  // Inverse of the camera's projection matrix
+            float4x4 _CameraInvView;        // Inverse of the camera's view matrix
+
+            v2f vert(appdata v)
             {
-                Varyings o;
-                o.positionCS = TransformObjectToHClip(v.positionOS);
+                v2f o;
+                o.pos = UnityObjectToClipPos(v.vertex);
                 o.uv = v.uv;
                 return o;
             }
 
-            // Fragment Shader: Sample the depth and convert to world position
-            half4 frag(Varyings i) : SV_Target
+            float3 GetWorldPosition(float2 uv)
             {
-                // Sample depth from the depth texture at the current UV coordinates
-                float depth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, sampler_CameraDepthTexture, i.uv);
+                // Sample the depth value
+                float depth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, uv);
 
-                // Normalize depth to the range [0, 1] using the near and far planes
-                depth = LinearEyeDepth(depth, _MyScreenParams.x, _MyScreenParams.y);
+                // Convert from screen space to normalized device coordinates
+                float4 screenPos = float4(uv * 2.0 - 1.0, depth, 1.0);
 
-                // Convert depth to clip space
-                float4 clipSpace = float4(i.uv * 2.0 - 1.0, depth * 2.0 - 1.0, 1.0);
+                // Convert from normalized device coordinates to camera space (view space)
+                float4 viewPos = mul(_CameraInvProjection, screenPos);
+                viewPos /= viewPos.w; // Homogeneous division
 
-                // Convert from clip space to world space
-                float4 worldPos = mul(_CameraInvViewProjection, clipSpace);
-                worldPos /= worldPos.w; // Perspective divide
+                // Convert from camera space to world space
+                float4 worldPos = mul(_CameraInvView, viewPos);
 
-                // Return the world position in the RGB channels (for sampling)
-                return half4(worldPos.xyz, 1.0);
+                return worldPos.xyz;
             }
 
-            // Function to convert from non-linear depth to linear depth
-            float LinearEyeDepth(float depth, float near, float far)
+            half4 frag(v2f i) : SV_Target
             {
-                // Converts the depth from non-linear to linear space
-                return near * far / (far - (far - near) * depth);
-            }
+                // Calculate world position from depth
+                float3 worldPos = GetWorldPosition(i.uv);
 
-            ENDHLSL
+                return half4(worldPos, 1.0);
+            }
+            ENDCG
         }
     }
 }

--- a/Assets/_Application/Samplers/DepthShader.shader
+++ b/Assets/_Application/Samplers/DepthShader.shader
@@ -2,66 +2,45 @@ Shader "Custom/WorldPositionFromDepth"
 {
     Properties
     {
-        _CameraDepthTexture ("Depth Texture", 2D) = "white" { }
+        _CameraDepthTexture ("Depth Texture", 2D) = "white" {}
     }
     SubShader
     {
-        Tags { "RenderType"="Opaque" }
         Pass
         {
+            Tags { "LightMode" = "Always" }
+            
             CGPROGRAM
             #pragma vertex vert
             #pragma fragment frag
+
             #include "UnityCG.cginc"
 
-            struct appdata
-            {
-                float4 vertex : POSITION;
-                float2 uv : TEXCOORD0;
-            };
-
-            struct v2f
-            {
-                float4 pos : POSITION;
-                float2 uv : TEXCOORD0;
-            };
-
             sampler2D _CameraDepthTexture;
-            float4x4 _CameraInvProjection;  // Inverse of the camera's projection matrix
-            float4x4 _CameraInvView;        // Inverse of the camera's view matrix
+            float4x4 _CameraInvProjection;
+
+            struct appdata { float4 vertex : POSITION; };
+            struct v2f { float4 pos : SV_POSITION; float2 uv : TEXCOORD0; };
 
             v2f vert(appdata v)
             {
                 v2f o;
                 o.pos = UnityObjectToClipPos(v.vertex);
-                o.uv = v.uv;
+                o.uv = o.pos.xy * 0.5 + 0.5; // Normalize UVs
                 return o;
             }
 
-            float3 GetWorldPosition(float2 uv)
+            float4 frag(v2f i) : SV_Target
             {
-                // Sample the depth value
-                float depth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, uv);
+                // Sample depth texture
+                float depth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, i.uv);
 
-                // Convert from screen space to normalized device coordinates
-                float4 screenPos = float4(uv * 2.0 - 1.0, depth, 1.0);
+                // Convert from screen space to world space
+                float4 clipPos = float4(i.uv * 2.0 - 1.0, depth, 1.0);
+                float4 worldPos = mul(_CameraInvProjection, clipPos);
+                worldPos /= worldPos.w; // Perspective divide
 
-                // Convert from normalized device coordinates to camera space (view space)
-                float4 viewPos = mul(_CameraInvProjection, screenPos);
-                viewPos /= viewPos.w; // Homogeneous division
-
-                // Convert from camera space to world space
-                float4 worldPos = mul(_CameraInvView, viewPos);
-
-                return worldPos.xyz;
-            }
-
-            half4 frag(v2f i) : SV_Target
-            {
-                // Calculate world position from depth
-                float3 worldPos = GetWorldPosition(i.uv);
-
-                return half4(worldPos, 1.0);
+                return worldPos; // Return world position as RGBA
             }
             ENDCG
         }

--- a/Assets/_Application/Samplers/DepthShader.shader.meta
+++ b/Assets/_Application/Samplers/DepthShader.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b02324e6281613a48907e5b20579e7bf
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Application/Samplers/DepthWorldPositionMaterial.mat
+++ b/Assets/_Application/Samplers/DepthWorldPositionMaterial.mat
@@ -1,0 +1,136 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: DepthWorldPositionMaterial
+  m_Shader: {fileID: 4800000, guid: 05e76e8020139194ea25ca34f3837ae9, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _WorldPositionTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &8698742401785837334
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7

--- a/Assets/_Application/Samplers/DepthWorldPositionMaterial.mat.meta
+++ b/Assets/_Application/Samplers/DepthWorldPositionMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6986404031f7a3147b16a3526abf03c1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Application/Samplers/OpticalRaycaster.cs
+++ b/Assets/_Application/Samplers/OpticalRaycaster.cs
@@ -1,44 +1,48 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.Rendering;
 
 namespace Netherlands3D.Twin.Samplers
 {
-    [RequireComponent(typeof(Camera))]
     public class OpticalRaycaster : MonoBehaviour
     {
         [SerializeField] private Camera depthCamera;
-        public RenderTexture worldPosRenderTexture;
-        float totalDepth = 0;
-        private Texture2D samplerTexture;
 
         [Header("Events")] [SerializeField] public UnityEvent<Vector3> OnDepthSampled;
-        
+
+        private List<RenderTexture> rtPool = new List<RenderTexture>();
+        private Dictionary<Vector3, GPURequest> activeRequests = new();
+
+
+        public struct GPURequest
+        {
+            public AsyncGPUReadbackRequest request;
+            public List<Action<Vector3>> callbacks;
+            public RenderTexture texture;
+
+            public GPURequest(AsyncGPUReadbackRequest request, RenderTexture texture, Action<Vector3> firstCallback)
+            {
+                this.request = request;
+                this.texture = texture; 
+                callbacks = new List<Action<Vector3>>();
+                callbacks.Add(firstCallback);
+            }
+        }
+
         void Start()
         {
-            if (depthCamera.targetTexture == null)
-            {
-                Debug.Log("Depth camera has no target texture. Please assign a render texture to the depth camera.", this.gameObject);
-                this.enabled = false;
-                return;
-            }
-
-            worldPosRenderTexture = new RenderTexture(1, 1, 0, RenderTextureFormat.Depth);
-            worldPosRenderTexture.graphicsFormat = UnityEngine.Experimental.Rendering.GraphicsFormat.R32G32B32A32_SFloat;
-            worldPosRenderTexture.depthStencilFormat = UnityEngine.Experimental.Rendering.GraphicsFormat.None;
-            worldPosRenderTexture.enableRandomWrite = true; // Allow GPU writes
-            worldPosRenderTexture.Create();
-
-            depthCamera.targetTexture = worldPosRenderTexture;
-
-            samplerTexture = new Texture2D(worldPosRenderTexture.width, worldPosRenderTexture.height, TextureFormat.RGBAFloat, false);
+            depthCamera.depthTextureMode = DepthTextureMode.Depth;
         }
 
         private void OnDestroy()
         {
-            Destroy(samplerTexture);
-            worldPosRenderTexture.Release();
+            //release all rendertextures
+            foreach (RenderTexture rt in rtPool)
+            {
+                rt.Release();
+            }
         }
 
         /// <summary>
@@ -47,55 +51,62 @@ namespace Netherlands3D.Twin.Samplers
         /// in a Coroutine with a WaitForEndOfFrame between every step.
         /// </summary>
         /// <returns></returns>
-        public void GetWorldPointAtCameraScreenPoint(Camera camera, Vector3 screenPoint, Action<Vector3> result)
+        public void GetWorldPointAsync(Vector3 screenPoint, Action<Vector3> result)
         {
-            AlignDepthCameraToScreenPoint(camera, screenPoint);
-            GetWorldPoint(result);
-        }
-
-
-        public void AlignDepthCameraToScreenPoint(Camera camera, Vector3 screenPoint)
-        {
-            //Align and rotate sampler camera to look at screenpoint
-            depthCamera.transform.position = camera.transform.position;
-            depthCamera.transform.LookAt(camera.ScreenToWorldPoint(new Vector3(screenPoint.x, screenPoint.y, camera.nearClipPlane)));
-        }
-
-        public void AlignDepthCameraFromPositionToDirection(Vector3 position, Vector3 direction)
-        {
-            //Align depth camera 
-            depthCamera.transform.SetPositionAndRotation(position, Quaternion.LookRotation(direction));
-        }
-
-        public void GetWorldPoint(Action<Vector3> gpuResult)
-        {
-            AsyncGPUReadback.Request(worldPosRenderTexture, 0, (request) =>
+            if (activeRequests.ContainsKey(screenPoint))
             {
-                if (request.hasError)
+                activeRequests[screenPoint].callbacks.Add(result);
+                return;
+            }
+
+            RenderTexture rt = GetRenderTexture();
+            depthCamera.targetTexture = rt;
+
+            //Align depthcamera to the main camera
+            depthCamera.transform.position = Camera.main.transform.position;
+            depthCamera.transform.LookAt(Camera.main.ScreenToWorldPoint(new Vector3(screenPoint.x, screenPoint.y, Camera.main.nearClipPlane)));
+            depthCamera.Render();
+            AsyncGPUReadbackRequest request = AsyncGPUReadback.Request(rt, 0, (req) =>
+            {
+                if (req.hasError)
                 {
                     Debug.LogError("Error in GPU readback");
+                    CompleteRequest(Vector3.zero, screenPoint, rt);
                     return;
-                }
-
-                // Get the raw byte data from the readback request
-                var data = request.GetData<Color>();             
+                }              
+                var data = req.GetData<Color>();
                 Color color = data[0];
                 Vector3 worldPos = new Vector3(color.r, color.g, color.b);
-                gpuResult.Invoke(worldPos);
+                CompleteRequest(worldPos, screenPoint, rt);
             });
+            activeRequests.Add(screenPoint, new GPURequest(request, rt, result));
+        }
 
-            //RenderTexture.active = worldPosRenderTexture;
-            //samplerTexture.ReadPixels(new Rect(0, 0, 1, 1), 0, 0);
-            //RenderTexture.active = null;
+        private void CompleteRequest(Vector3 worldPosition, Vector3 screenPoint, RenderTexture rt)
+        {
+            foreach (var callback in activeRequests[screenPoint].callbacks)
+                callback.Invoke(worldPosition);
+            activeRequests.Remove(screenPoint);
+            rtPool.Add(rt);
+        }
 
-            //Color sampledColor = samplerTexture.GetPixel(0, 0);
-
-            //// De-normalize color to world position
-            //return new Vector3(
-            //    sampledColor.r,
-            //    sampledColor.g,
-            //    sampledColor.b
-            //);
+        private RenderTexture GetRenderTexture()
+        {
+            RenderTexture renderTexture = null;
+            if (rtPool.Count > 0)
+            {
+                renderTexture = rtPool[0];
+                rtPool.RemoveAt(0);
+            }
+            else
+            {
+                renderTexture = new RenderTexture(1, 1, 0, RenderTextureFormat.Depth);
+                renderTexture.graphicsFormat = UnityEngine.Experimental.Rendering.GraphicsFormat.R32G32B32A32_SFloat;
+                renderTexture.depthStencilFormat = UnityEngine.Experimental.Rendering.GraphicsFormat.None;
+                //renderTexture.enableRandomWrite = true; // Allow GPU writes
+                renderTexture.Create();
+            }            
+            return renderTexture;
         }
     }
 }

--- a/Assets/_Application/Samplers/PointerToWorldPosition.cs
+++ b/Assets/_Application/Samplers/PointerToWorldPosition.cs
@@ -16,8 +16,12 @@ namespace Netherlands3D.Twin.Samplers
         private void Update()
         {
             var screenPoint = Pointer.current.position.ReadValue();
-            WorldPoint = opticalRaycaster.GetWorldPointAtCameraScreenPoint(Camera.main, screenPoint);
-            Debug.Log(WorldPoint);
+            opticalRaycaster.GetWorldPointAtCameraScreenPoint(Camera.main, screenPoint, w =>
+            {
+                WorldPoint = w;
+                Debug.Log(WorldPoint);
+            });
+            
         }
     }
 }

--- a/Assets/_Application/Samplers/PointerToWorldPosition.cs
+++ b/Assets/_Application/Samplers/PointerToWorldPosition.cs
@@ -17,6 +17,7 @@ namespace Netherlands3D.Twin.Samplers
         {
             var screenPoint = Pointer.current.position.ReadValue();
             WorldPoint = opticalRaycaster.GetWorldPointAtCameraScreenPoint(Camera.main, screenPoint);
+            Debug.Log(WorldPoint);
         }
     }
 }

--- a/Assets/_Application/Samplers/PointerToWorldPosition.cs
+++ b/Assets/_Application/Samplers/PointerToWorldPosition.cs
@@ -16,12 +16,10 @@ namespace Netherlands3D.Twin.Samplers
         private void Update()
         {
             var screenPoint = Pointer.current.position.ReadValue();
-            opticalRaycaster.GetWorldPointAtCameraScreenPoint(Camera.main, screenPoint, w =>
+            opticalRaycaster.GetWorldPointAsync(screenPoint, w =>
             {
                 WorldPoint = w;
-                Debug.Log(WorldPoint);
-            });
-            
+            });            
         }
     }
 }

--- a/Assets/_Application/Samplers/VisualizeWorldPosition.shader
+++ b/Assets/_Application/Samplers/VisualizeWorldPosition.shader
@@ -1,0 +1,49 @@
+Shader "Custom/VisualizeWorldPosition"
+{
+    Properties
+    {
+        _WorldPositionTexture ("World Position Texture", 2D) = "white" {}
+    }
+    SubShader
+    {
+        Pass
+        {
+            Tags { "LightMode" = "Always" }
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            sampler2D _WorldPositionTexture;
+
+            // Define a simple structure to pass vertex data
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            // Simple vertex shader to create a full-screen quad
+            v2f vert(float4 vertex : POSITION)
+            {
+                v2f o;
+                o.pos = vertex; // Use the default vertex positions of the full screen quad
+                o.uv = vertex.xy * 0.5 + 0.5; // Convert from [-1, 1] to [0, 1] for texture sampling
+                return o;
+            }
+
+            // Fragment shader to visualize the world position data
+            float4 frag(v2f i) : SV_Target
+            {
+                // Sample world position from the texture
+                float4 worldPos = tex2D(_WorldPositionTexture, i.uv);
+                
+                // Colorize based on world position (for visualization purposes)
+                return float4(worldPos.xyz * 0.5 + 0.5, 1.0); // Normalize to [0, 1] range for visualization
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/_Application/Samplers/VisualizeWorldPosition.shader.meta
+++ b/Assets/_Application/Samplers/VisualizeWorldPosition.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 05e76e8020139194ea25ca34f3837ae9
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Functionalities/ObjectLibrary/Scripts/ObjectLibraryButton.cs
+++ b/Assets/_Functionalities/ObjectLibrary/Scripts/ObjectLibraryButton.cs
@@ -36,41 +36,26 @@ namespace Netherlands3D.Functionalities.ObjectLibrary
         
         protected virtual void CreateObject()
         {
-            StartCoroutine(CreateObjectCoroutine());
-        }
-
-        private IEnumerator CreateObjectCoroutine()
-        {
-            var spawnPoint = ObjectPlacementUtility.GetSpawnPoint();            
-
+            var spawnPoint = ObjectPlacementUtility.GetSpawnPoint();
             var opticalRaycaster = FindAnyObjectByType<OpticalRaycaster>();
-            if(opticalRaycaster)
+            if (opticalRaycaster)
             {
-                //Retrieve spawnpoint from optical raycaster a few frames in a row to make sure the depth texture is updated
-                var frames = 3;
-                var centerOfViewport = new Vector3(Screen.width * 0.5f, Screen.height / 2, 0);
-                for (int i = 0; i < frames; i++)
+                var centerOfViewport = new Vector3(Screen.width * 0.5f, Screen.height * 0.5f, 0);
+                opticalRaycaster.GetWorldPointAsync(centerOfViewport, w =>
                 {
-                    yield return new WaitForEndOfFrame();
-                    opticalRaycaster.GetWorldPointAtCameraScreenPoint(Camera.main, centerOfViewport, w =>
+                    var opticalSpawnPoint = w;
+                    if (opticalSpawnPoint != Vector3.zero)
                     {
-                        var opticalSpawnPoint = w;
-                        if (opticalSpawnPoint != Vector3.zero)
-                        {
-                            spawnPoint = opticalSpawnPoint;
-                        }
-                    });                    
-                }
-            }
-            
-            var newObject = Instantiate(prefab, spawnPoint, prefab.transform.rotation);
-            var layerComponent = newObject.GetComponent<HierarchicalObjectLayerGameObject>();
-            if (!layerComponent)
-                layerComponent = newObject.AddComponent<HierarchicalObjectLayerGameObject>();
-            
-            layerComponent.Name = prefab.name;
+                        spawnPoint = opticalSpawnPoint;
+                    }
+                    var newObject = Instantiate(prefab, spawnPoint, prefab.transform.rotation);
+                    var layerComponent = newObject.GetComponent<HierarchicalObjectLayerGameObject>();
+                    if (!layerComponent)
+                        layerComponent = newObject.AddComponent<HierarchicalObjectLayerGameObject>();
 
-            yield return null;
+                    layerComponent.Name = prefab.name;
+                });
+            }
         }
     }
 }

--- a/Assets/_Functionalities/ObjectLibrary/Scripts/ObjectLibraryButton.cs
+++ b/Assets/_Functionalities/ObjectLibrary/Scripts/ObjectLibraryButton.cs
@@ -52,11 +52,14 @@ namespace Netherlands3D.Functionalities.ObjectLibrary
                 for (int i = 0; i < frames; i++)
                 {
                     yield return new WaitForEndOfFrame();
-                    var opticalSpawnPoint = opticalRaycaster.GetWorldPointAtCameraScreenPoint(Camera.main, centerOfViewport);
-                    if (opticalSpawnPoint != Vector3.zero)
+                    opticalRaycaster.GetWorldPointAtCameraScreenPoint(Camera.main, centerOfViewport, w =>
                     {
-                        spawnPoint = opticalSpawnPoint;
-                    }
+                        var opticalSpawnPoint = w;
+                        if (opticalSpawnPoint != Vector3.zero)
+                        {
+                            spawnPoint = opticalSpawnPoint;
+                        }
+                    });                    
                 }
             }
             

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -18,7 +18,7 @@ PlayerSettings:
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
   m_ShowUnitySplashScreen: 1
-  m_ShowUnitySplashLogo: 1
+  m_ShowUnitySplashLogo: 0
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
   m_SplashScreenLogoStyle: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -18,7 +18,7 @@ PlayerSettings:
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
   m_ShowUnitySplashScreen: 1
-  m_ShowUnitySplashLogo: 0
+  m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
   m_SplashScreenLogoStyle: 0


### PR DESCRIPTION
2 new shaders, to process the depth of the current rendertexture, the second to convert it back to a worldposition colored pixel, these shaders prevent readpixel readbacks which are very heavy.
now using a pool of optical requests which hold an asyncgpureadback request (webgl supported).
foreach request a depthcamera with 1 pixel is temporary enabled and disabled after use, preventing a depthcamera.Render call.