### PR TITLE
optimizing bottombar.update

### DIFF
--- a/Assets/_Application/_Twin/UI/BottomBar.cs
+++ b/Assets/_Application/_Twin/UI/BottomBar.cs
@@ -1,4 +1,7 @@
 using Netherlands3D.Coordinates;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using TMPro;
 using UnityEngine;
 
@@ -9,6 +12,20 @@ namespace Netherlands3D.Twin.UI
         [Header("Camera coordinates")]
         [SerializeField] private TextMeshProUGUI coordinatesText;
         [SerializeField] private string coordinateFormat = "x{0} y{1} z{2}";
+
+        private string[] cachedValues = new string[10] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" };
+        private string[] currentSet = new string[10];
+        private string[] xyz = new string[3] { "x", "y", "z" };
+        private string negative = "-";
+        private string space = " ";
+
+        private StringBuilder builder;
+        private Vector3Int lastPosition;
+
+        private void Start()
+        {
+            builder = new StringBuilder();
+        }
         public void Update()
         {
             ApplyCameraPositionToText();
@@ -25,11 +42,49 @@ namespace Netherlands3D.Twin.UI
              );
             var rd = CoordinateConverter.ConvertTo(cameraCoordinate, CoordinateSystem.RDNAP);
 
-            //Replace the placeholders with the coordinates
-            coordinatesText.text = coordinateFormat
-                .Replace("{0}", rd.Points[0].ToString("0"))
-                .Replace("{1}", rd.Points[1].ToString("0"))
-                .Replace("{2}", rd.Points[2].ToString("0"));
+            Vector3Int position = new Vector3Int(Mathf.RoundToInt((float)rd.value1), Mathf.RoundToInt((float)rd.value2), Mathf.RoundToInt((float)rd.value3));
+            if (lastPosition != position)
+            {
+                builder.Clear();
+                AppendValueString(position.x, xyz[0], builder);
+                AppendValueString(position.z, xyz[1], builder);
+                AppendValueString(position.y, xyz[2], builder);
+                coordinatesText.text = builder.ToString();
+                lastPosition = position;
+            }            
+        }
+
+        private void AppendValueString(int value, string dimension, StringBuilder builder)
+        {
+            bool neg;
+            int count;
+            for (int i = 0; i < currentSet.Length; i++)
+                currentSet[i] = null;
+            builder.Append(dimension);
+            string[] result = GetNumberString(value, currentSet, out neg, out count);
+            if (neg)
+                builder.Append(negative);
+            for (int i = 0; i < count; i++)
+                builder.Append(currentSet[count - i - 1]);
+            builder.Append(space);
+        }
+
+
+        private string[] GetNumberString(int number, string[] set, out bool negative, out int count)
+        {
+            negative = number < 0;
+            number = Mathf.Abs(number);
+            int index = 0;
+            while (number > 0)
+            {                
+                int digit = number % 10;
+                number /= 10;
+                set[index] = cachedValues[digit];
+                index++;
+            }
+            //set.Reverse();
+            count = index;
+            return set;
         }
     }
 }

--- a/Assets/_Application/_Twin/UI/BottomBar.cs
+++ b/Assets/_Application/_Twin/UI/BottomBar.cs
@@ -1,6 +1,4 @@
 using Netherlands3D.Coordinates;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using TMPro;
 using UnityEngine;
@@ -60,7 +58,7 @@ namespace Netherlands3D.Twin.UI
             for (int i = 0; i < currentSet.Length; i++)
                 currentSet[i] = space;
             builder.Append(dimension);
-            char[] result = GetNumberString(value, currentSet, out neg, out count);
+            GetNumberForCharSet(value, currentSet, out neg, out count);
             if (neg)
                 builder.Append(negative);
             for (int i = 0; i < count; i++)
@@ -69,7 +67,7 @@ namespace Netherlands3D.Twin.UI
         }
 
 
-        private char[] GetNumberString(int number, char[] set, out bool negative, out int count)
+        private void GetNumberForCharSet(int number, char[] set, out bool negative, out int count)
         {
             negative = number < 0;
             number = Mathf.Abs(number);
@@ -82,7 +80,6 @@ namespace Netherlands3D.Twin.UI
                 index++;
             }
             count = index;
-            return set;
         }
     }
 }

--- a/Assets/_Application/_Twin/UI/BottomBar.cs
+++ b/Assets/_Application/_Twin/UI/BottomBar.cs
@@ -15,8 +15,8 @@ namespace Netherlands3D.Twin.UI
         private char[] cachedValues = new char[10] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
         private char[] currentSet = new char[10];
         private char[] xyz = new char[3] { 'x', 'y', 'z' };
-        private char negative = '-';
-        private char space = ' ';
+        private const char negative = '-';
+        private const char space = ' ';
 
         private StringBuilder builder;
         private Vector3Int lastPosition;
@@ -41,7 +41,7 @@ namespace Netherlands3D.Twin.UI
              );
             var rd = CoordinateConverter.ConvertTo(cameraCoordinate, CoordinateSystem.RDNAP);
 
-            Vector3Int position = new Vector3Int(Mathf.RoundToInt((float)rd.value1), Mathf.RoundToInt((float)rd.value2), Mathf.RoundToInt((float)rd.value3));
+            Vector3Int position = new Vector3Int((int)rd.value1, (int)rd.value2, (int)rd.value3);
             if (lastPosition != position)
             {
                 builder.Clear();
@@ -50,7 +50,7 @@ namespace Netherlands3D.Twin.UI
                 AppendValueString(position.y, xyz[2], builder);
                 coordinatesText.text = builder.ToString();
                 lastPosition = position;
-            }            
+            }
         }
 
         private void AppendValueString(int value, char dimension, StringBuilder builder)
@@ -58,7 +58,7 @@ namespace Netherlands3D.Twin.UI
             bool neg;
             int count;
             for (int i = 0; i < currentSet.Length; i++)
-                currentSet[i] = ' ';
+                currentSet[i] = space;
             builder.Append(dimension);
             char[] result = GetNumberString(value, currentSet, out neg, out count);
             if (neg)
@@ -75,13 +75,12 @@ namespace Netherlands3D.Twin.UI
             number = Mathf.Abs(number);
             int index = 0;
             while (number > 0)
-            {                
+            {
                 int digit = number % 10;
                 number /= 10;
                 set[index] = cachedValues[digit];
                 index++;
             }
-            //set.Reverse();
             count = index;
             return set;
         }

--- a/Assets/_Application/_Twin/UI/BottomBar.cs
+++ b/Assets/_Application/_Twin/UI/BottomBar.cs
@@ -11,13 +11,12 @@ namespace Netherlands3D.Twin.UI
     {
         [Header("Camera coordinates")]
         [SerializeField] private TextMeshProUGUI coordinatesText;
-        [SerializeField] private string coordinateFormat = "x{0} y{1} z{2}";
 
-        private string[] cachedValues = new string[10] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" };
-        private string[] currentSet = new string[10];
-        private string[] xyz = new string[3] { "x", "y", "z" };
-        private string negative = "-";
-        private string space = " ";
+        private char[] cachedValues = new char[10] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+        private char[] currentSet = new char[10];
+        private char[] xyz = new char[3] { 'x', 'y', 'z' };
+        private char negative = '-';
+        private char space = ' ';
 
         private StringBuilder builder;
         private Vector3Int lastPosition;
@@ -54,14 +53,14 @@ namespace Netherlands3D.Twin.UI
             }            
         }
 
-        private void AppendValueString(int value, string dimension, StringBuilder builder)
+        private void AppendValueString(int value, char dimension, StringBuilder builder)
         {
             bool neg;
             int count;
             for (int i = 0; i < currentSet.Length; i++)
-                currentSet[i] = null;
+                currentSet[i] = ' ';
             builder.Append(dimension);
-            string[] result = GetNumberString(value, currentSet, out neg, out count);
+            char[] result = GetNumberString(value, currentSet, out neg, out count);
             if (neg)
                 builder.Append(negative);
             for (int i = 0; i < count; i++)
@@ -70,7 +69,7 @@ namespace Netherlands3D.Twin.UI
         }
 
 
-        private string[] GetNumberString(int number, string[] set, out bool negative, out int count)
+        private char[] GetNumberString(int number, char[] set, out bool negative, out int count)
         {
             negative = number < 0;
             number = Mathf.Abs(number);


### PR DESCRIPTION
checking if position changed, if not then dont update text +
using string builder to reduce memory overhead. (from 3kb to 1.2kb) +
caching method for simple seperate string values brought the memory down from 1.2kb to 128 bytes.
the 128b are stringbuilder.tostring which cannot be optimized