### PR TITLE
Bugfix/transform handles panel crash

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -7764,11 +7764,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 29cbe7fa0ca3eb9428ef4851d9f9e11e,
         type: 2}
-    - target: {fileID: 6145256048111018074, guid: 9963fec33e379324db2affcb3f83332f,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 6155497104461542838, guid: 9963fec33e379324db2affcb3f83332f,
         type: 3}
       propertyPath: m_Size

--- a/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectLayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectLayerGameObject.cs
@@ -163,9 +163,15 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject
         public override void OnSelect()
         {
             var transformInterfaceToggle = FindAnyObjectByType<TransformHandleInterfaceToggle>(FindObjectsInactive.Include); //todo remove FindObjectOfType
-
-            if (transformInterfaceToggle)
+            
+            if (!transformInterfaceToggle)
+            {
+                Debug.LogError("Transform handles interface toggles not found, cannot set transform target");
+            }
+            else
+            {
                 transformInterfaceToggle.SetTransformTarget(gameObject);
+            }
         }
 
         public override void OnDeselect()

--- a/Assets/_Application/_Twin/UI/ToggleGroupItem.cs
+++ b/Assets/_Application/_Twin/UI/ToggleGroupItem.cs
@@ -33,7 +33,7 @@ namespace Netherlands3D.Twin.UI
 
         public void SetInteractable(bool interactable)
         {
-            toggle.interactable = interactable;
+            Toggle.interactable = interactable;
             icon.color = interactable ? enabledIconColor : disabledIconColor;
         }
     }

--- a/Assets/_Application/_Twin/UI/ToggleGroupItem.cs
+++ b/Assets/_Application/_Twin/UI/ToggleGroupItem.cs
@@ -3,6 +3,7 @@ using UnityEngine.UI;
 
 namespace Netherlands3D.Twin.UI
 {
+    [RequireComponent(typeof(Toggle))]
     public class ToggleGroupItem : MonoBehaviour
     {
         private Toggle toggle;


### PR DESCRIPTION
Transform handles UI toggles were accidentally disabled. This caused a crash when trying to activate them. this fix re-enables the panel and adds a safeguard to allow the application to continue if the toggles are disabled.