### PR TITLE
Bugfix/remove coordinatesystem unity references

### DIFF
--- a/Assets/Prefabs/UI/InspectorPanels/Download/DownloadInspector.prefab
+++ b/Assets/Prefabs/UI/InspectorPanels/Download/DownloadInspector.prefab
@@ -1142,10 +1142,10 @@ MonoBehaviour:
   DisplayCrs: 28992
   areaSelection: {fileID: 11400000, guid: e64696f66bdcc5343ad26d8c620d845a, type: 2}
   renderedThumbnail: {fileID: 6867477000835044279}
-  northExtentTextField: {fileID: 3135639470450376762}
-  southExtentTextField: {fileID: 8598277423336867337}
-  eastExtentTextField: {fileID: 3719487516998976869}
-  westExtentTextField: {fileID: 1784231394480833021}
+  northExtentTextField: {fileID: 3719487516998976869}
+  southExtentTextField: {fileID: 1784231394480833021}
+  eastExtentTextField: {fileID: 3135639470450376762}
+  westExtentTextField: {fileID: 8598277423336867337}
   copyNorthEastExtentButton: {fileID: 197758433612143890}
   copySouthWestExtentButton: {fileID: 2551304673583623924}
   popoutPrefab: {fileID: 3977518503646692406, guid: 0c75754029f6c6940848c9f8bfe7edb9,
@@ -2124,8 +2124,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 956.5, y: -519.7088}
-  m_SizeDelta: {x: 1909, y: 0}
+  m_AnchoredPosition: {x: 1921, y: -519.7088}
+  m_SizeDelta: {x: 3838, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5195422349626505141
 CanvasRenderer:
@@ -4741,6 +4741,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Scrollbar Vertical
       objectReference: {fileID: 0}
+    - target: {fileID: 1781802643554129927, guid: 115ed422e629e4645bfb5c97e46c2e9b,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3286731148600885667, guid: 115ed422e629e4645bfb5c97e46c2e9b,
         type: 3}
       propertyPath: m_Pivot.x
@@ -4844,17 +4849,17 @@ PrefabInstance:
     - target: {fileID: 3690174632879616221, guid: 115ed422e629e4645bfb5c97e46c2e9b,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3690174632879616221, guid: 115ed422e629e4645bfb5c97e46c2e9b,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5797817625417347508, guid: 115ed422e629e4645bfb5c97e46c2e9b,
         type: 3}
       propertyPath: m_Size
-      value: 0.99989283
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5797817625417347508, guid: 115ed422e629e4645bfb5c97e46c2e9b,
         type: 3}

--- a/Assets/_Application/Configuration/SetupWizard.cs
+++ b/Assets/_Application/Configuration/SetupWizard.cs
@@ -60,8 +60,11 @@ namespace Netherlands3D.Twin.Configuration
                 return;
 
             //If we are not setting the origin from the coordinate input fields; use the origin of the camera position
-            var cameraCoordinate = new Coordinate(CoordinateSystem.Unity, Camera.main.transform.position.x, Camera.main.transform.position.y, Camera.main.transform.position.z);
-            ProjectData.Current.CameraPosition = cameraCoordinate.Convert(CoordinateSystem.RDNAP).Points;
+            var cameraCoordinate = new Coordinate(Camera.main.transform.position).Convert(CoordinateSystem.RDNAP);
+            ProjectData.Current.CameraPosition = new double[]
+            {
+                cameraCoordinate.value1, cameraCoordinate.value2, cameraCoordinate.value3
+            };
             
             //Update url with some cooldown (browsers do not like setting url too often)
             if(urlNeedsUpdate && Time.frameCount - lastUrlUpdate > urlUpdateFrameCooldown)

--- a/Assets/_Application/Layers/LayerTypes/HierarchicalObject/Properties/TransformPropertySection.cs
+++ b/Assets/_Application/Layers/LayerTypes/HierarchicalObject/Properties/TransformPropertySection.cs
@@ -227,9 +227,9 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject.Properties
         {
             var rdCoordinate = CoordinateConverter.ConvertTo(coordinate, CoordinateSystem.RDNAP);
             
-            position.xField.SetTextWithoutNotify($"{rdCoordinate.Points[0].ToString(formatString, CultureInfo.InvariantCulture)}{positionUnitCharacter}");
-            position.yField.SetTextWithoutNotify($"{rdCoordinate.Points[1].ToString(formatString, CultureInfo.InvariantCulture)}{positionUnitCharacter}");
-            position.zField.SetTextWithoutNotify($"{rdCoordinate.Points[2].ToString(formatString, CultureInfo.InvariantCulture)}{positionUnitCharacter}");
+            position.xField.SetTextWithoutNotify($"{rdCoordinate.easting.ToString(formatString, CultureInfo.InvariantCulture)}{positionUnitCharacter}");
+            position.yField.SetTextWithoutNotify($"{rdCoordinate.northing.ToString(formatString, CultureInfo.InvariantCulture)}{positionUnitCharacter}");
+            position.zField.SetTextWithoutNotify($"{rdCoordinate.height.ToString(formatString, CultureInfo.InvariantCulture)}{positionUnitCharacter}");
         }
 
         private void UpdateRotationFields(Vector3 eulerAngles)

--- a/Assets/_Application/Projects/ProjectDataCameraUpdater.cs
+++ b/Assets/_Application/Projects/ProjectDataCameraUpdater.cs
@@ -45,8 +45,8 @@ namespace Netherlands3D.Twin.Projects
 
         private void SaveCurrentCameraTransform()
         {
-            var cameraCoordinate = new Coordinate(CoordinateSystem.Unity, transform.position.x, transform.position.y, transform.position.z);
-            var cameraCoordinateRD = cameraCoordinate.Convert(CoordinateSystem.RDNAP).ToVector3RD();
+            var cameraCoordinate = new Coordinate(transform.position).Convert(CoordinateSystem.RDNAP);
+            var cameraCoordinateRD = cameraCoordinate.ToVector3RD();
             var cameraRotation = transform.eulerAngles;
 
             ProjectData.Current.CameraPosition = new double[] { cameraCoordinateRD.x, cameraCoordinateRD.y, cameraCoordinateRD.z };

--- a/Assets/_Application/Utility/CityJsonExporter.cs
+++ b/Assets/_Application/Utility/CityJsonExporter.cs
@@ -71,7 +71,7 @@ namespace Netherlands3D.Twin.Utility
             // Write transform
             stringWriter.WriteLine("  \"transform\": {");
             stringWriter.WriteLine($"    \"scale\": [{scale.x}, {scale.y}, {scale.z}],");
-            stringWriter.WriteLine($"    \"translate\": [{rdCoordinate.Points[0]}, {rdCoordinate.Points[1]}, {rdCoordinate.Points[2]}]");
+            stringWriter.WriteLine($"    \"translate\": [{rdCoordinate.value1}, {rdCoordinate.value2}, {rdCoordinate.value3}]");
             stringWriter.WriteLine("  },");
 
             stringWriter.WriteLine("  \"CityObjects\": {");

--- a/Assets/_Application/_Twin/UI/BottomBar.cs
+++ b/Assets/_Application/_Twin/UI/BottomBar.cs
@@ -31,12 +31,7 @@ namespace Netherlands3D.Twin.UI
         private void ApplyCameraPositionToText()
         {
             //Use coordinate convert to convert camera to rd coordinates
-            var cameraCoordinate = new Coordinate(
-                CoordinateSystem.Unity,
-                Camera.main.transform.position.x,
-                Camera.main.transform.position.y,
-                Camera.main.transform.position.z
-             );
+            var cameraCoordinate = new Coordinate(Camera.main.transform.position);
             var rd = CoordinateConverter.ConvertTo(cameraCoordinate, CoordinateSystem.RDNAP);
 
             Vector3Int position = new Vector3Int((int)rd.value1, (int)rd.value2, (int)rd.value3);

--- a/Assets/_BuildingBlocks/Configuration/Scripts/Configuration.cs
+++ b/Assets/_BuildingBlocks/Configuration/Scripts/Configuration.cs
@@ -39,7 +39,7 @@ namespace Netherlands3D.Twin.Configuration
             get => origin;
             set
             {
-                var roundedValue = new Coordinate(value.CoordinateSystem, (int)value.Points[0], (int)value.Points[1], (int)value.Points[2]);
+                var roundedValue = new Coordinate(value.CoordinateSystem, (int)value.value1, (int)value.value2, (int)value.value3);
                 origin = roundedValue;
                 OnOriginChanged.Invoke(roundedValue);
             }
@@ -199,7 +199,7 @@ namespace Netherlands3D.Twin.Configuration
             var enabledfunctionalities = Functionalities.Where(functionality => functionality.IsEnabled).Select(functionality => functionality.Id);
 
             var originRDNAP = origin.Convert(CoordinateSystem.RDNAP);
-            urlBuilder.AddQueryParameter("origin", $"{(int)originRDNAP.Points[0]},{(int)originRDNAP.Points[1]},{(int)originRDNAP.Points[2]}");
+            urlBuilder.AddQueryParameter("origin", $"{(int)originRDNAP.value1},{(int)originRDNAP.value2},{(int)originRDNAP.value3}");
             urlBuilder.AddQueryParameter("functionalities", string.Join(',', enabledfunctionalities.ToArray()));
             foreach (var functionality in Functionalities)
             {
@@ -223,9 +223,9 @@ namespace Netherlands3D.Twin.Configuration
                 ["origin"] = new JSONObject()
                 {
                     ["epsg"] = origin.CoordinateSystem,
-                    ["x"] = origin.Points[0],
-                    ["y"] = origin.Points[1],
-                    ["z"] = origin.Points[2],
+                    ["x"] = origin.value1,
+                    ["y"] = origin.value2,
+                    ["z"] = origin.value3,
                 },
                 ["functionalities"] = new JSONObject()
             };

--- a/Assets/_Functionalities/AreaDownload/Scripts/UI/DownloadInspector.cs
+++ b/Assets/_Functionalities/AreaDownload/Scripts/UI/DownloadInspector.cs
@@ -124,10 +124,12 @@ namespace Netherlands3D.Functionalities.AreaDownload.UI
         // the y equals the center of the bound) or a 3D results (containing the full bounds)
         private (Coordinate southWest, Coordinate northEast) ConvertBoundsToCoordinates(Bounds bounds)
         {
-            var min = new Coordinate(CoordinateSystem.Unity, bounds.min.x, bounds.center.y, bounds.min.z);
+            var minUnityPosition = new Vector3(bounds.min.x, bounds.center.y, bounds.min.z);
+            var min = new Coordinate(minUnityPosition);
             var southWest = CoordinateConverter.ConvertTo(min, DisplayCrs);
-            
-            var max = new Coordinate(CoordinateSystem.Unity, bounds.max.x, bounds.center.y, bounds.max.z);
+
+            var maxUnityPosition = new Vector3(bounds.max.x, bounds.center.y, bounds.max.z);
+            var max = new Coordinate(maxUnityPosition);
             var northEast = CoordinateConverter.ConvertTo(max, DisplayCrs);
 
             return (southWest, northEast);

--- a/Assets/_Functionalities/AreaDownload/Scripts/UI/DownloadInspector.cs
+++ b/Assets/_Functionalities/AreaDownload/Scripts/UI/DownloadInspector.cs
@@ -82,8 +82,8 @@ namespace Netherlands3D.Functionalities.AreaDownload.UI
             eastExtentTextField.text = southWestAndNorthEast.northEast.easting.ToString("0");
             westExtentTextField.text = southWestAndNorthEast.southWest.easting.ToString("0");
 
-            southWestTooltip.Show($"X: {southExtentTextField.text}\nY: {westExtentTextField.text}", southWestAndNorthEast.Item1, true);
-            northEastTooltip.Show($"X: {northExtentTextField.text}\nY: {eastExtentTextField.text}", southWestAndNorthEast.Item2, true);
+            southWestTooltip.Show($"X: {westExtentTextField.text}\nY: {southExtentTextField.text}", southWestAndNorthEast.Item1, true);
+            northEastTooltip.Show($"X: {eastExtentTextField.text}\nY: {northExtentTextField.text}", southWestAndNorthEast.Item2, true);
         }
 
         private void OnSelectionBoundsChanged(Bounds selectedArea)

--- a/Assets/_Functionalities/AreaDownload/Scripts/UI/DownloadInspector.cs
+++ b/Assets/_Functionalities/AreaDownload/Scripts/UI/DownloadInspector.cs
@@ -77,10 +77,10 @@ namespace Netherlands3D.Functionalities.AreaDownload.UI
         {
             var southWestAndNorthEast = ConvertBoundsToCoordinates(selectedArea);
             
-            northExtentTextField.text = southWestAndNorthEast.northEast.Points[0].ToString("0");
-            southExtentTextField.text = southWestAndNorthEast.southWest.Points[0].ToString("0");
-            eastExtentTextField.text = southWestAndNorthEast.northEast.Points[1].ToString("0");
-            westExtentTextField.text = southWestAndNorthEast.southWest.Points[1].ToString("0");
+            northExtentTextField.text = southWestAndNorthEast.northEast.northing.ToString("0");
+            southExtentTextField.text = southWestAndNorthEast.southWest.northing.ToString("0");
+            eastExtentTextField.text = southWestAndNorthEast.northEast.easting.ToString("0");
+            westExtentTextField.text = southWestAndNorthEast.southWest.easting.ToString("0");
 
             southWestTooltip.Show($"X: {southExtentTextField.text}\nY: {westExtentTextField.text}", southWestAndNorthEast.Item1, true);
             northEastTooltip.Show($"X: {northExtentTextField.text}\nY: {eastExtentTextField.text}", southWestAndNorthEast.Item2, true);

--- a/Assets/_Functionalities/ObjectInformation/Scripts/FeatureMapping.cs
+++ b/Assets/_Functionalities/ObjectInformation/Scripts/FeatureMapping.cs
@@ -133,8 +133,8 @@ namespace Netherlands3D.Functionalities.ObjectInformation
         public static BoundingBox CreateBoundingBoxForFeature(Feature feature, IGeoJsonVisualisationLayer layer)
         {
             Bounds featureBounds = layer.GetFeatureBounds(feature);
-            Coordinate bottomLeft = new Coordinate(CoordinateSystem.Unity, featureBounds.min.x, featureBounds.min.y, featureBounds.min.z);
-            Coordinate topRight = new Coordinate(CoordinateSystem.Unity, featureBounds.max.x, featureBounds.max.y, featureBounds.max.z);
+            Coordinate bottomLeft = new Coordinate(featureBounds.min);
+            Coordinate topRight = new Coordinate(featureBounds.max);
             Coordinate blWgs84 = bottomLeft.Convert(CoordinateSystem.WGS84_LatLon);
             Coordinate trWgs84 = topRight.Convert(CoordinateSystem.WGS84_LatLon);
             BoundingBox boundingBox = new BoundingBox(blWgs84, trWgs84);

--- a/Assets/_Functionalities/UrbanReLeaf/Scripts/SensorLayer/SensorDataController.cs
+++ b/Assets/_Functionalities/UrbanReLeaf/Scripts/SensorLayer/SensorDataController.cs
@@ -77,12 +77,7 @@ namespace Netherlands3D.Functionalities.UrbanReLeaf
         
         public Vector2Int GetTileKeyFromUnityPosition(Vector3 position, int tileSize)
         {
-            var unityCoordinate = new Coordinate(
-                CoordinateSystem.Unity,
-                position.x,
-                position.y,
-                position.z
-            );
+            var unityCoordinate = new Coordinate(position);
             Coordinate coord = CoordinateConverter.ConvertTo(unityCoordinate, CoordinateSystem.RD);
             Vector2Int key = new Vector2Int(Mathf.RoundToInt(((float)coord.Points[0] - 0.5f * tileSize) / 1000) * 1000, Mathf.RoundToInt(((float)coord.Points[1] - 0.5f * tileSize) / 1000) * 1000);
             return key;
@@ -90,12 +85,7 @@ namespace Netherlands3D.Functionalities.UrbanReLeaf
 
         public Vector2Int GetRDPositionFromUnityPosition(Vector3 position)
         {
-            var unityCoordinate = new Coordinate(
-                CoordinateSystem.Unity,
-                position.x,
-                position.y,
-                position.z
-            );
+            var unityCoordinate = new Coordinate(position);
             Coordinate coord = CoordinateConverter.ConvertTo(unityCoordinate, CoordinateSystem.RD);
             Vector2Int key = new Vector2Int((int)coord.Points[0], (int)coord.Points[1]);
             return key;
@@ -150,11 +140,9 @@ namespace Netherlands3D.Functionalities.UrbanReLeaf
                 coordinate[1],
                 coordinate[0],
                 0
-            );
-            Coordinate coord = CoordinateConverter.ConvertTo(unityCoordinate, CoordinateSystem.Unity);
-            Vector3 position = coord.ToUnity();
-            position.y = height;
-            return position;
+            ).ToUnity();
+            unityCoordinate.y = height;
+            return unityCoordinate;
         }
     }
 }

--- a/Assets/_Functionalities/UrbanReLeaf/Scripts/SensorLayer/SensorDataController.cs
+++ b/Assets/_Functionalities/UrbanReLeaf/Scripts/SensorLayer/SensorDataController.cs
@@ -72,14 +72,14 @@ namespace Netherlands3D.Functionalities.UrbanReLeaf
                 0
             );
             Coordinate coord = CoordinateConverter.ConvertTo(unityCoordinate, CoordinateSystem.WGS84);
-            return new double[2] { coord.Points[1], coord.Points[0] };
+            return new double[2] { coord.easting, coord.northing };
         }  
         
         public Vector2Int GetTileKeyFromUnityPosition(Vector3 position, int tileSize)
         {
             var unityCoordinate = new Coordinate(position);
             Coordinate coord = CoordinateConverter.ConvertTo(unityCoordinate, CoordinateSystem.RD);
-            Vector2Int key = new Vector2Int(Mathf.RoundToInt(((float)coord.Points[0] - 0.5f * tileSize) / 1000) * 1000, Mathf.RoundToInt(((float)coord.Points[1] - 0.5f * tileSize) / 1000) * 1000);
+            Vector2Int key = new Vector2Int(Mathf.RoundToInt(((float)coord.easting - 0.5f * tileSize) / 1000) * 1000, Mathf.RoundToInt(((float)coord.northing - 0.5f * tileSize) / 1000) * 1000);
             return key;
         }
 
@@ -87,7 +87,7 @@ namespace Netherlands3D.Functionalities.UrbanReLeaf
         {
             var unityCoordinate = new Coordinate(position);
             Coordinate coord = CoordinateConverter.ConvertTo(unityCoordinate, CoordinateSystem.RD);
-            Vector2Int key = new Vector2Int((int)coord.Points[0], (int)coord.Points[1]);
+            Vector2Int key = new Vector2Int((int)coord.easting, (int)coord.northing);
             return key;
         }
         

--- a/Assets/_Functionalities/Wms/Scripts/ImageProjectionLayer.cs
+++ b/Assets/_Functionalities/Wms/Scripts/ImageProjectionLayer.cs
@@ -142,7 +142,7 @@ namespace Netherlands3D.Functionalities.Wms
                 origin.y,
                 0.0d
             );
-            var originCoordinate = CoordinateConverter.ConvertTo(rdCoordinate, CoordinateSystem.Unity).ToVector3();
+            var originCoordinate = rdCoordinate.ToUnity();
 
             originCoordinate.y = ProjectorHeight;
             tile.gameObject.transform.position = originCoordinate; //projector is now at same position as the layer !?          


### PR DESCRIPTION
Removed references to CoordinateSystem.Unity and Coordinate.Points in several parts of the project

https://cdn-dev-ams-3da.azureedge.net/autobuild/bugfix/remove-coordinatesystem-unity-references/162507981/