### PR TITLE
Add .bat files to easily host a local build

### DIFF
--- a/bin/start-local-server-with-ngrok.bat
+++ b/bin/start-local-server-with-ngrok.bat
@@ -1,0 +1,2 @@
+start "Netherlands3D" %cd%/bin/start-local-server.bat
+ngrok http 8000

--- a/bin/start-local-server.bat
+++ b/bin/start-local-server.bat
@@ -1,0 +1,2 @@
+cd Build
+python -m http.server 8000


### PR DESCRIPTION
When you use Build and Run, Unity will start a local webserver; but if you want to test the application later you always need to use Build and Run.

This is inconvenient when you want to do things like change the DefaultTemplate file in the build folder and test it, or continue testing later. To help with this I have introduced the start-local-server.bat file that will use a locally installed Python installation to start a webserver on port 8000 with the contents of the Build folder.

To view the twin, go to http://localhost:8000 and it will load.

The second script is when you have ngrok installed on your local machine, to expose your local Build folder to the internet. This can be useful when a coworker -or other person- wants to see how far you are or when you want to check something during development.