### PR TITLE
Geojson Mesh memory leak

### DIFF
--- a/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/FeaturePolygonVisualisations.cs
+++ b/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/FeaturePolygonVisualisations.cs
@@ -127,7 +127,7 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.GeoJsonLayers
             {
                 foreach (var visualisation in visualisations)
                 {
-                    visualisation.GetComponent<Renderer>().material = material;
+                    visualisation.VisualisationMaterial = material;
                 }
             }
 

--- a/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/GeoJSONPolygonLayer.cs
+++ b/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/GeoJSONPolygonLayer.cs
@@ -49,8 +49,7 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.GeoJsonLayers
             List<PolygonVisualisation> visualisations = data.Data;
             foreach (PolygonVisualisation polygon in visualisations)
             {
-                //TODO would really like to have the meshfilter or mesh cached within the polygonvisualisation (in external package)
-                meshes.Add(polygon.GetComponent<MeshFilter>().mesh);
+                meshes.Add(polygon.PolygonMesh);
             }
 
             return meshes;
@@ -73,11 +72,10 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.GeoJsonLayers
         /// <param name="vertexColors"></param>
         public void SetVisualisationColor(Transform transform, List<Mesh> meshes, Color color)
         {
-            //TODO would really like to have the meshrenderer cached within the polygonvisualisation (in external package)
             PolygonVisualisation visualisation = GetPolygonVisualisationByMesh(meshes);
             if(visualisation != null)
             {
-                visualisation.gameObject.GetComponent<MeshRenderer>().material.color = color;
+                visualisation.VisualisationMaterial.color = color;
             }
         }
 
@@ -89,13 +87,12 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.GeoJsonLayers
         /// <returns></returns>
         public PolygonVisualisation GetPolygonVisualisationByMesh(List<Mesh> meshes)
         {
-            //TODO would really like to have the meshrenderer cached within the polygonvisualisation (in external package)
             foreach (KeyValuePair<Feature, FeaturePolygonVisualisations> fpv in spawnedVisualisations)
             {
                 List<PolygonVisualisation> visualisations = fpv.Value.Data;
                 foreach (PolygonVisualisation pv in visualisations)
                 {
-                    if (!meshes.Contains(pv.GetComponent<MeshFilter>().mesh)) continue;
+                    if (!meshes.Contains(pv.PolygonMesh)) continue;
     
                     return pv;
                 }
@@ -105,7 +102,6 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.GeoJsonLayers
 
         public void SetVisualisationColorToDefault()
         {
-            //TODO would really like to have the meshrenderer cached within the polygonvisualisation (in external package)
             Color defaultColor = GetRenderColor();
             foreach (KeyValuePair<Feature, FeaturePolygonVisualisations> fpv in spawnedVisualisations)
             {
@@ -113,7 +109,7 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.GeoJsonLayers
                 foreach (PolygonVisualisation pv in visualisations)
                 {
                     if (pv != null)
-                        pv.gameObject.GetComponent<MeshRenderer>().material.color = defaultColor;
+                        pv.VisualisationMaterial.color = defaultColor;
                 }
             }
         }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -29,7 +29,7 @@
     "eu.netherlands3d.minimap": "1.1.6",
     "eu.netherlands3d.obj-importer": "1.2.2",
     "eu.netherlands3d.periodic-snapshots": "2.0.0",
-    "eu.netherlands3d.selection-tools": "2.6.1",
+    "eu.netherlands3d.selection-tools": "2.7.0",
     "eu.netherlands3d.simplejson": "1.0.0",
     "eu.netherlands3d.snapshots": "2.0.0",
     "eu.netherlands3d.subobjects": "1.4.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -430,7 +430,7 @@
       "url": "https://package.openupm.com"
     },
     "eu.netherlands3d.selection-tools": {
-      "version": "2.6.1",
+      "version": "2.7.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
Fixed duplicate meshes by accessing PolygonMesh property and removed getcomponents to assign materials directly. Required an update of the SelectionTools package to v 2.7.0

https://cdn-dev-ams-3da.azureedge.net/autobuild/bugfix/geojson-memory-leak/feature/?1303251428