### PR TITLE
disabled error properties toggle by default

### DIFF
--- a/Assets/Prefabs/UI/Layers/LayerUI.prefab
+++ b/Assets/Prefabs/UI/Layers/LayerUI.prefab
@@ -2576,7 +2576,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  m_IsOn: 1
+  m_IsOn: 0
 --- !u!1 &7119179143932802346
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
error properties toggle was on by default, requiring it to be clicked twice to open the property panel, this pr fixes that