### PR TITLE
Feature/UI terrein laag kleuren

### DIFF
--- a/Assets/Prefabs/UI/Sidebar/GeneralComponents/ColorPicker.prefab
+++ b/Assets/Prefabs/UI/Sidebar/GeneralComponents/ColorPicker.prefab
@@ -7008,6 +7008,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2dc85356250718d4bbd600418b5f7166, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  supportsTransparency: 1
   color: {r: 1, g: 1, b: 1, a: 1}
   colorDisplays:
   - {fileID: 8346595411931782716}

--- a/Assets/Prefabs/UI/Sidebar/GeneralComponents/ColorPicker.prefab
+++ b/Assets/Prefabs/UI/Sidebar/GeneralComponents/ColorPicker.prefab
@@ -5677,7 +5677,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 162.5, y: -171.5}
+  m_AnchoredPosition: {x: 162.5, y: -44}
   m_SizeDelta: {x: 325, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3291269154772184193

--- a/Assets/Prefabs/UI/Sidebar/GeneralComponents/ColorSettings.prefab
+++ b/Assets/Prefabs/UI/Sidebar/GeneralComponents/ColorSettings.prefab
@@ -186,8 +186,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1268.5, y: -91}
-  m_SizeDelta: {x: 2533, y: 182}
+  m_AnchoredPosition: {x: 948.5, y: -91}
+  m_SizeDelta: {x: 1893, y: 182}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5316886491802838686
 CanvasRenderer:
@@ -1371,7 +1371,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 16, y: -9}
-  m_SizeDelta: {x: 2501, y: 392}
+  m_SizeDelta: {x: 1861, y: 392}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &5570243877115260438
 MonoBehaviour:
@@ -1454,8 +1454,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1266.5, y: -0.5}
-  m_SizeDelta: {x: 2501, y: 1}
+  m_AnchoredPosition: {x: 946.5, y: -0.5}
+  m_SizeDelta: {x: 1861, y: 1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &95516492834240588
 CanvasRenderer:
@@ -1750,8 +1750,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1268.5, y: -127}
-  m_SizeDelta: {x: 2533, y: 254}
+  m_AnchoredPosition: {x: 948.5, y: -126}
+  m_SizeDelta: {x: 1893, y: 252}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8423532939466892870
 CanvasRenderer:
@@ -1868,7 +1868,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: -0}
-  m_SizeDelta: {x: 2535, y: 534}
+  m_SizeDelta: {x: 1895, y: 454}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &6485666077548469037
 MonoBehaviour:
@@ -1946,7 +1946,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 16, y: -73}
-  m_SizeDelta: {x: 2501, y: 24}
+  m_SizeDelta: {x: 1861, y: 24}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1448842018461083204
 MonoBehaviour:
@@ -2106,8 +2106,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1250.5, y: -24}
-  m_SizeDelta: {x: 2501, y: 48}
+  m_AnchoredPosition: {x: 930.5, y: -24}
+  m_SizeDelta: {x: 1861, y: 48}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &142588521670999957
 CanvasRenderer:
@@ -2317,7 +2317,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: -0}
-  m_SizeDelta: {x: 2535, y: 182}
+  m_SizeDelta: {x: 1895, y: 182}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &9122227890730904662
 MonoBehaviour:
@@ -2394,8 +2394,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1266.5, y: -0.5}
-  m_SizeDelta: {x: 2501, y: 1}
+  m_AnchoredPosition: {x: 946.5, y: -0.5}
+  m_SizeDelta: {x: 1861, y: 1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8361735604198386287
 CanvasRenderer:
@@ -2491,8 +2491,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1266.5, y: -183.5}
-  m_SizeDelta: {x: 2501, y: 35}
+  m_AnchoredPosition: {x: 946.5, y: -173.5}
+  m_SizeDelta: {x: 1861, y: 35}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7772436652186864642
 MonoBehaviour:
@@ -2651,8 +2651,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1266.5, y: -131.5}
-  m_SizeDelta: {x: 2501, y: 45}
+  m_AnchoredPosition: {x: 946.5, y: -126.5}
+  m_SizeDelta: {x: 1861, y: 35}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &598239386482865998
 CanvasRenderer:
@@ -2708,7 +2708,7 @@ MonoBehaviour:
   m_MinWidth: -1
   m_MinHeight: -1
   m_PreferredWidth: -1
-  m_PreferredHeight: 45
+  m_PreferredHeight: 35
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
@@ -2749,7 +2749,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: -102}
-  m_SizeDelta: {x: 2533, y: 57}
+  m_SizeDelta: {x: 1893, y: 57}
   m_Pivot: {x: 0, y: 0}
 --- !u!222 &6849430676686417613
 CanvasRenderer:
@@ -2820,8 +2820,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0}
-  m_SizeDelta: {x: 2535, y: 254}
+  m_AnchoredPosition: {x: 0, y: -198}
+  m_SizeDelta: {x: 1895, y: 252}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &7271246139783015807
 MonoBehaviour:
@@ -3346,8 +3346,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1266.5, y: -22.5}
-  m_SizeDelta: {x: 2533, y: 45}
+  m_AnchoredPosition: {x: 946.5, y: -22.5}
+  m_SizeDelta: {x: 1893, y: 45}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4039058777951981759
 CanvasRenderer:
@@ -3816,7 +3816,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &3122154520102641343
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3836,8 +3836,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1266.5, y: -494}
-  m_SizeDelta: {x: 2533, y: 80}
+  m_AnchoredPosition: {x: 946.5, y: -494}
+  m_SizeDelta: {x: 1893, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2095881564999549
 CanvasRenderer:
@@ -3987,8 +3987,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: -254}
-  m_SizeDelta: {x: 2533, y: 209}
+  m_AnchoredPosition: {x: 0, y: -252}
+  m_SizeDelta: {x: 1893, y: 207}
   m_Pivot: {x: 0, y: 0}
 --- !u!222 &4505764415882730576
 CanvasRenderer:
@@ -4014,7 +4014,7 @@ MonoBehaviour:
     m_Left: 16
     m_Right: 16
     m_Top: 0
-    m_Bottom: 8
+    m_Bottom: 16
   m_ChildAlignment: 0
   m_Spacing: 12
   m_ChildForceExpandWidth: 1
@@ -4215,8 +4215,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1266.5, y: -0.5}
-  m_SizeDelta: {x: 2501, y: 1}
+  m_AnchoredPosition: {x: 946.5, y: -0.5}
+  m_SizeDelta: {x: 1861, y: 1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &9153380635704945946
 CanvasRenderer:
@@ -4315,8 +4315,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1266.5, y: -22.5}
-  m_SizeDelta: {x: 2533, y: 45}
+  m_AnchoredPosition: {x: 946.5, y: -22.5}
+  m_SizeDelta: {x: 1893, y: 45}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4145922604707650653
 CanvasRenderer:
@@ -4415,8 +4415,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1268.5, y: -267}
-  m_SizeDelta: {x: 2533, y: 534}
+  m_AnchoredPosition: {x: 948.5, y: -227}
+  m_SizeDelta: {x: 1893, y: 454}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5481138399908193874
 CanvasRenderer:
@@ -5061,8 +5061,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1259.5, y: -17.5}
-  m_SizeDelta: {x: 2451, y: 25}
+  m_AnchoredPosition: {x: 939.5, y: -17.5}
+  m_SizeDelta: {x: 1811, y: 25}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4312039137550122600
 CanvasRenderer:
@@ -5568,8 +5568,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1266.5, y: -22.5}
-  m_SizeDelta: {x: 2533, y: 45}
+  m_AnchoredPosition: {x: 946.5, y: -22.5}
+  m_SizeDelta: {x: 1893, y: 45}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8706227639667935280
 CanvasRenderer:
@@ -5794,8 +5794,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1266.5, y: -142}
-  m_SizeDelta: {x: 2533, y: 80}
+  m_AnchoredPosition: {x: 946.5, y: -142}
+  m_SizeDelta: {x: 1893, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5899350736370912052
 CanvasRenderer:
@@ -5892,7 +5892,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: -454}
-  m_SizeDelta: {x: 2533, y: 409}
+  m_SizeDelta: {x: 1893, y: 409}
   m_Pivot: {x: 0, y: 0}
 --- !u!222 &2057125704863301313
 CanvasRenderer:
@@ -6388,7 +6388,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 16, y: -9}
-  m_SizeDelta: {x: 2501, y: 40}
+  m_SizeDelta: {x: 1861, y: 40}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &6852691727252582034
 MonoBehaviour:
@@ -6634,7 +6634,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 16, y: -13}
-  m_SizeDelta: {x: 2501, y: 48}
+  m_SizeDelta: {x: 1861, y: 48}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &2131417674499503901
 CanvasRenderer:
@@ -6792,7 +6792,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2501
+      value: 1861
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -6837,7 +6837,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1250.5
+      value: 930.5
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -6946,7 +6946,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2501
+      value: 1861
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -6991,7 +6991,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1250.5
+      value: 930.5
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -7510,7 +7510,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2501
+      value: 1861
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -7555,7 +7555,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1250.5
+      value: 930.5
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -7664,7 +7664,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2501
+      value: 1861
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -7709,7 +7709,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1250.5
+      value: 930.5
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -7803,7 +7803,7 @@ PrefabInstance:
     - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2535
+      value: 1895
       objectReference: {fileID: 0}
     - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
@@ -7848,12 +7848,12 @@ PrefabInstance:
     - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1267.5
+      value: 947.5
       objectReference: {fileID: 0}
     - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -897.5
+      value: -149.5
       objectReference: {fileID: 0}
     - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
@@ -7883,12 +7883,12 @@ PrefabInstance:
     - target: {fileID: 1389967864631557269, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2535
+      value: 1895
       objectReference: {fileID: 0}
     - target: {fileID: 1389967864631557269, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1267.5
+      value: 947.5
       objectReference: {fileID: 0}
     - target: {fileID: 1389967864631557269, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
@@ -7943,7 +7943,7 @@ PrefabInstance:
     - target: {fileID: 4932190116421537328, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2535
+      value: 1895
       objectReference: {fileID: 0}
     - target: {fileID: 4932190116421537328, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
@@ -7953,7 +7953,7 @@ PrefabInstance:
     - target: {fileID: 4932190116421537328, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1267.5
+      value: 947.5
       objectReference: {fileID: 0}
     - target: {fileID: 4932190116421537328, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
@@ -8008,12 +8008,12 @@ PrefabInstance:
     - target: {fileID: 8065810425275369335, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2535
+      value: 1895
       objectReference: {fileID: 0}
     - target: {fileID: 8065810425275369335, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1267.5
+      value: 947.5
       objectReference: {fileID: 0}
     - target: {fileID: 8065810425275369335, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
@@ -8092,7 +8092,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2501
+      value: 1861
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8137,7 +8137,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1250.5
+      value: 930.5
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8656,7 +8656,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2501
+      value: 1861
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8701,7 +8701,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1250.5
+      value: 930.5
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8810,7 +8810,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2501
+      value: 1861
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8855,7 +8855,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1250.5
+      value: 930.5
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8964,7 +8964,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2501
+      value: 1861
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9009,7 +9009,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1250.5
+      value: 930.5
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9123,7 +9123,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2501
+      value: 1861
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9168,7 +9168,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1250.5
+      value: 930.5
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9277,7 +9277,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2501
+      value: 1861
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9322,7 +9322,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1250.5
+      value: 930.5
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9846,7 +9846,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2501
+      value: 1861
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9891,7 +9891,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1250.5
+      value: 930.5
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -10166,7 +10166,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2501
+      value: 1861
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -10211,7 +10211,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1250.5
+      value: 930.5
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -10471,7 +10471,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -10481,12 +10481,12 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 2501
+      value: 1861
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -10531,7 +10531,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1250.5
+      value: 930.5
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}

--- a/Assets/Prefabs/UI/Sidebar/GeneralComponents/ColorSettings.prefab
+++ b/Assets/Prefabs/UI/Sidebar/GeneralComponents/ColorSettings.prefab
@@ -1467,10 +1467,10 @@ RectTransform:
   - {fileID: 2684084550564866428}
   m_Father: {fileID: 8369835421755871687}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 16, y: -9}
-  m_SizeDelta: {x: 1861, y: 392}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &5570243877115260438
 MonoBehaviour:
@@ -1948,7 +1948,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &6849286827281429832
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1967,7 +1967,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: -0}
-  m_SizeDelta: {x: 1895, y: 454}
+  m_SizeDelta: {x: 1895, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &6485666077548469037
 MonoBehaviour:
@@ -2569,10 +2569,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 8369835421755871687}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 946.5, y: -0.5}
-  m_SizeDelta: {x: 1861, y: 1}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8361735604198386287
 CanvasRenderer:
@@ -3659,10 +3659,10 @@ RectTransform:
   - {fileID: 8680525039006279899}
   m_Father: {fileID: 1183036900900035091}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 946.5, y: -22.5}
-  m_SizeDelta: {x: 1893, y: 45}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4039058777951981759
 CanvasRenderer:
@@ -4731,7 +4731,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 948.5, y: -227}
-  m_SizeDelta: {x: 1893, y: 454}
+  m_SizeDelta: {x: 1893, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5481138399908193874
 CanvasRenderer:
@@ -6459,10 +6459,10 @@ RectTransform:
   - {fileID: 8485659025928402752}
   m_Father: {fileID: 1183036900900035091}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: -454}
-  m_SizeDelta: {x: 1893, y: 409}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
 --- !u!222 &2057125704863301313
 CanvasRenderer:
@@ -7348,7 +7348,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -7358,17 +7358,17 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1861
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -7408,12 +7408,12 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 930.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -184
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -7502,7 +7502,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -7512,17 +7512,17 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1861
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -7562,12 +7562,12 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 930.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -376
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8066,7 +8066,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8076,17 +8076,17 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1861
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8126,12 +8126,12 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 930.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -280
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8220,7 +8220,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8230,17 +8230,17 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1861
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8280,12 +8280,12 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 930.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -56
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8648,7 +8648,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8658,17 +8658,17 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1861
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -8708,12 +8708,12 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 930.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -120
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9212,7 +9212,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9222,17 +9222,17 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1861
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9272,12 +9272,12 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 930.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -152
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9366,7 +9366,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9376,17 +9376,17 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1861
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9426,12 +9426,12 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 930.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -216
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9520,7 +9520,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9530,17 +9530,17 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1861
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9580,12 +9580,12 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 930.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -88
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9679,7 +9679,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9689,17 +9689,17 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1861
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9739,12 +9739,12 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 930.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -312
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9833,7 +9833,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9843,17 +9843,17 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1861
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -9893,12 +9893,12 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 930.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -344
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -10402,7 +10402,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -10412,17 +10412,17 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1861
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -10462,12 +10462,12 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 930.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -248
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -10927,7 +10927,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -10937,17 +10937,17 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1861
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -10987,12 +10987,12 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 930.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -24
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}

--- a/Assets/Prefabs/UI/Sidebar/GeneralComponents/ColorSettings.prefab
+++ b/Assets/Prefabs/UI/Sidebar/GeneralComponents/ColorSettings.prefab
@@ -775,6 +775,105 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1204705837606436880
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 798140695652879785}
+  - component: {fileID: 5402151307992276273}
+  - component: {fileID: 3479953458881955230}
+  - component: {fileID: 4585244044970573562}
+  m_Layer: 5
+  m_Name: Header
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &798140695652879785
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1204705837606436880}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5368478449701657908}
+  - {fileID: 5186440380848176962}
+  - {fileID: 3915501177672614675}
+  m_Father: {fileID: 1542811091964184020}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 946.5, y: -57.5}
+  m_SizeDelta: {x: 1893, y: 115}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5402151307992276273
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1204705837606436880}
+  m_CullTransparentMesh: 1
+--- !u!114 &3479953458881955230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1204705837606436880}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4585244044970573562
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1204705837606436880}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: 115
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &1211847464767804089
 GameObject:
   m_ObjectHideFlags: 0
@@ -2359,6 +2458,84 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 2
+--- !u!1 &3034832261379580020
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5697055579500551276}
+  - component: {fileID: 4904293047586237247}
+  - component: {fileID: 2313233870238880609}
+  m_Layer: 5
+  m_Name: Terugknop_Titel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5697055579500551276
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3034832261379580020}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1542811091964184020}
+  m_Father: {fileID: 4996155142956460685}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0}
+  m_SizeDelta: {x: 1895, y: 115}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &4904293047586237247
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3034832261379580020}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 2
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 16
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &2313233870238880609
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3034832261379580020}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 2
 --- !u!1 &3204157887242797670
 GameObject:
   m_ObjectHideFlags: 0
@@ -2820,7 +2997,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: -198}
+  m_AnchoredPosition: {x: 0, y: -0}
   m_SizeDelta: {x: 1895, y: 252}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &7271246139783015807
@@ -2863,6 +3040,144 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 2
+--- !u!1 &4355349079237431937
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5186440380848176962}
+  - component: {fileID: 1369792525107966576}
+  - component: {fileID: 4862289517354483151}
+  m_Layer: 5
+  m_Name: Body_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5186440380848176962
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4355349079237431937}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 798140695652879785}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 24.6183, y: -71.60369}
+  m_SizeDelta: {x: -98.7633, y: 68.66}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1369792525107966576
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4355349079237431937}
+  m_CullTransparentMesh: 1
+--- !u!114 &4862289517354483151
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4355349079237431937}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Stel een stijlregel samen voor een kenmerk van deze laag. Deze wordt toegepast
+    op alle geselecteerde attributen.
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 32ddfb0cac272234c9b6f41500eb9afb, type: 2}
+  m_sharedMaterial: {fileID: -6169979864846303504, guid: 32ddfb0cac272234c9b6f41500eb9afb,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4283775282
+  m_fontColor: {r: 0.19607843, g: 0.22352941, b: 0.33333334, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0.8838501, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4376594994635414711
 GameObject:
   m_ObjectHideFlags: 0
@@ -4884,6 +5199,124 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &6173935397187281489
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1542811091964184020}
+  - component: {fileID: 3515284514450717830}
+  - component: {fileID: 8981645776092884250}
+  - component: {fileID: 7546959432980991491}
+  - component: {fileID: 4383217194205378029}
+  m_Layer: 5
+  m_Name: Parent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1542811091964184020
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6173935397187281489}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 798140695652879785}
+  m_Father: {fileID: 5697055579500551276}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 948.5, y: -57.5}
+  m_SizeDelta: {x: 1893, y: 115}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3515284514450717830
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6173935397187281489}
+  m_CullTransparentMesh: 1
+--- !u!114 &8981645776092884250
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6173935397187281489}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7546959432980991491
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6173935397187281489}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &4383217194205378029
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6173935397187281489}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 2
 --- !u!1 &6188061875383979324
 GameObject:
   m_ObjectHideFlags: 0
@@ -5756,6 +6189,143 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7435830836284619434
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5368478449701657908}
+  - component: {fileID: 1051077359547572376}
+  - component: {fileID: 7517417965384514764}
+  m_Layer: 5
+  m_Name: TitleText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5368478449701657908
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7435830836284619434}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 798140695652879785}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 14.791691, y: -23}
+  m_SizeDelta: {x: -118.41662, y: 19.8673}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1051077359547572376
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7435830836284619434}
+  m_CullTransparentMesh: 1
+--- !u!114 &7517417965384514764
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7435830836284619434}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Kenmerk toevoegen of bewerken
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 32ddfb0cac272234c9b6f41500eb9afb, type: 2}
+  m_sharedMaterial: {fileID: -6169979864846303504, guid: 32ddfb0cac272234c9b6f41500eb9afb,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4283775282
+  m_fontColor: {r: 0.19607843, g: 0.22352941, b: 0.33333334, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 1
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0.8838501, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &7520135573041993485
 GameObject:
   m_ObjectHideFlags: 0
@@ -6034,6 +6604,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 5697055579500551276}
   - {fileID: 2688462733659480497}
   - {fileID: 6849286827281429832}
   - {fileID: 1362166455719586789}
@@ -10110,6 +10681,211 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 6784462213876937296}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8258252378532483575
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 798140695652879785}
+    m_Modifications:
+    - target: {fileID: 309393778111507294, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_Name
+      value: UIButton_Terug
+      objectReference: {fileID: 0}
+    - target: {fileID: 1518934753131645070, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1518934753131645070, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1518934753131645070, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 33.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 1518934753131645070, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 15.74
+      objectReference: {fileID: 0}
+    - target: {fileID: 1518934753131645070, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 49.635002
+      objectReference: {fileID: 0}
+    - target: {fileID: 1518934753131645070, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -24
+      objectReference: {fileID: 0}
+    - target: {fileID: 2083294629274030569, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 8da33d9924087234bb277b7848a82d29,
+        type: 3}
+    - target: {fileID: 2818050124483050654, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_PixelsPerUnitMultiplier
+      value: 1.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3663558178498436140, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -42
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8229404338314957064, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8229404338314957064, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8229404338314957064, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 8229404338314957064, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 8229404338314957064, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8229404338314957064, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 8229404338314957064, guid: 9b03494031e3bb643997bd5432bc015b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -24
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9b03494031e3bb643997bd5432bc015b, type: 3}
+--- !u!224 &3915501177672614675 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4957780787399807716, guid: 9b03494031e3bb643997bd5432bc015b,
+    type: 3}
+  m_PrefabInstance: {fileID: 8258252378532483575}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8352680895518122440
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10471,7 +11247,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
@@ -10481,7 +11257,7 @@ PrefabInstance:
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2616552838660092146, guid: 2e9e32516b497cc47b378e422fb16002,
         type: 3}

--- a/Assets/Prefabs/UI/Sidebar/GeneralComponents/Colorpicker_Components/ColorSwatchPrefab.prefab
+++ b/Assets/Prefabs/UI/Sidebar/GeneralComponents/Colorpicker_Components/ColorSwatchPrefab.prefab
@@ -948,7 +948,7 @@ PrefabInstance:
     - target: {fileID: 2949840199555609578, guid: 60ea0d62f86e9c747a5b314e91540ba7,
         type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7837714925288523348, guid: 60ea0d62f86e9c747a5b314e91540ba7,
         type: 3}

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -235,7 +235,7 @@ PrefabInstance:
     - target: {fileID: 196147295931165467, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 401
+      value: 86
       objectReference: {fileID: 0}
     - target: {fileID: 196147295931165467, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
         type: 3}
@@ -465,7 +465,7 @@ PrefabInstance:
     - target: {fileID: 4051989295808076046, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 401
+      value: 86
       objectReference: {fileID: 0}
     - target: {fileID: 4455766772432284239, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
         type: 3}
@@ -506,6 +506,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5191896555998020033, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_Padding.m_Left
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5191896555998020033, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_Padding.m_Right
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5191896555998020033, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_Padding.m_Bottom
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 6116430045280311012, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
         type: 3}
@@ -795,7 +810,7 @@ PrefabInstance:
     - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 268
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
@@ -875,12 +890,12 @@ PrefabInstance:
     - target: {fileID: 1389967864631557269, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 268
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 1389967864631557269, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 134
+      value: 150
       objectReference: {fileID: 0}
     - target: {fileID: 1389967864631557269, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
@@ -915,7 +930,7 @@ PrefabInstance:
     - target: {fileID: 4932190116421537328, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 268
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 4932190116421537328, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
@@ -925,7 +940,7 @@ PrefabInstance:
     - target: {fileID: 4932190116421537328, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 134
+      value: 150
       objectReference: {fileID: 0}
     - target: {fileID: 4932190116421537328, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
@@ -936,6 +951,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: ColorPicker
+      objectReference: {fileID: 0}
+    - target: {fileID: 5078733024073835164, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7908207433689781745, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
@@ -965,12 +985,12 @@ PrefabInstance:
     - target: {fileID: 8065810425275369335, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 268
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 8065810425275369335, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 134
+      value: 150
       objectReference: {fileID: 0}
     - target: {fileID: 8065810425275369335, guid: eacd2d5be98dec243bc44bf8b2083c85,
         type: 3}
@@ -1571,7 +1591,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 150, y: -35}
-  m_SizeDelta: {x: 268, y: 70}
+  m_SizeDelta: {x: 300, y: 70}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1226297199
 MonoBehaviour:

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -4302,6 +4302,11 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1894488453890193722, guid: 9963fec33e379324db2affcb3f83332f,
+        type: 3}
+      propertyPath: tooltipText
+      value: Lagenpaneel
+      objectReference: {fileID: 0}
     - target: {fileID: 1959453458440521006, guid: 9963fec33e379324db2affcb3f83332f,
         type: 3}
       propertyPath: m_AnchorMax.y

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -209,6 +209,397 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b7fd482478be5cd40b562430e460a7a5, type: 3}
+--- !u!1001 &247449954
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7732943800119484193}
+    m_Modifications:
+    - target: {fileID: 196147295931165467, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 196147295931165467, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 196147295931165467, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 196147295931165467, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 401
+      objectReference: {fileID: 0}
+    - target: {fileID: 196147295931165467, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 196147295931165467, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 307914543616400351, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 307914543616400351, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 307914543616400351, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 307914543616400351, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 307914543616400351, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -320
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -12
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1832947868301165430, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2093818850592775062, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_Name
+      value: Secondary_Properties
+      objectReference: {fileID: 0}
+    - target: {fileID: 2093818850592775062, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2506915388718837148, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2900213596821770582, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2900213596821770582, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2900213596821770582, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2900213596821770582, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2900213596821770582, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2900213596821770582, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2919702952523497022, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2919702952523497022, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2919702952523497022, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2919702952523497022, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2919702952523497022, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2919702952523497022, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4051989295808076046, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 401
+      objectReference: {fileID: 0}
+    - target: {fileID: 4455766772432284239, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 4455766772432284239, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_fontSizeBase
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 5143299636637219252, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5143299636637219252, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5143299636637219252, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5143299636637219252, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5143299636637219252, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5143299636637219252, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6116430045280311012, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6116430045280311012, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6116430045280311012, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6116430045280311012, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6116430045280311012, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6116430045280311012, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7490855002457903577, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7490855002457903577, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7490855002457903577, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7490855002457903577, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7490855002457903577, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7490855002457903577, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8782374927704821134, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      propertyPath: m_PreferredWidth
+      value: 24
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 353826641309993575, guid: 0c06ae567b919a344b5a17ba8c5c4cab, type: 3}
+    - {fileID: 5452677576771536053, guid: 0c06ae567b919a344b5a17ba8c5c4cab, type: 3}
+    - {fileID: 3343504015431018353, guid: 0c06ae567b919a344b5a17ba8c5c4cab, type: 3}
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 196147295931165467, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1226297198}
+    - targetCorrespondingSourceObject: {fileID: 196147295931165467, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 364619773}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0c06ae567b919a344b5a17ba8c5c4cab, type: 3}
+--- !u!224 &247449955 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 977714122496267502, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+    type: 3}
+  m_PrefabInstance: {fileID: 247449954}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &247449956 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 196147295931165467, guid: 0c06ae567b919a344b5a17ba8c5c4cab,
+    type: 3}
+  m_PrefabInstance: {fileID: 247449954}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &307044924 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2794549335201400503, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
@@ -363,6 +754,240 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 73a3583486de62c4a82ee0734c80f1bf, type: 3}
+--- !u!1001 &364619772
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 247449956}
+    m_Modifications:
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 268
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 299
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -235.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1389967864631557269, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1389967864631557269, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1389967864631557269, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 268
+      objectReference: {fileID: 0}
+    - target: {fileID: 1389967864631557269, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 134
+      objectReference: {fileID: 0}
+    - target: {fileID: 1389967864631557269, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -127.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531357645974589374, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531357645974589374, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1531357645974589374, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4932190116421537328, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4932190116421537328, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4932190116421537328, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 268
+      objectReference: {fileID: 0}
+    - target: {fileID: 4932190116421537328, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 255
+      objectReference: {fileID: 0}
+    - target: {fileID: 4932190116421537328, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 134
+      objectReference: {fileID: 0}
+    - target: {fileID: 4932190116421537328, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -171.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5078733024073835164, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_Name
+      value: ColorPicker
+      objectReference: {fileID: 0}
+    - target: {fileID: 7908207433689781745, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7908207433689781745, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7908207433689781745, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8065810425275369335, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8065810425275369335, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8065810425275369335, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 268
+      objectReference: {fileID: 0}
+    - target: {fileID: 8065810425275369335, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 134
+      objectReference: {fileID: 0}
+    - target: {fileID: 8065810425275369335, guid: eacd2d5be98dec243bc44bf8b2083c85,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -22
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: eacd2d5be98dec243bc44bf8b2083c85, type: 3}
+--- !u!224 &364619773 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 464194535855973160, guid: eacd2d5be98dec243bc44bf8b2083c85,
+    type: 3}
+  m_PrefabInstance: {fileID: 364619772}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &392614949
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -911,6 +1536,71 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 7732943800119484192}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1226297197
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1226297198}
+  - component: {fileID: 1226297201}
+  - component: {fileID: 1226297199}
+  m_Layer: 5
+  m_Name: Empty_Space
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1226297198
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1226297197}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 247449956}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 150, y: -35}
+  m_SizeDelta: {x: 268, y: 70}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1226297199
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1226297197}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: 70
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!222 &1226297201
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1226297197}
+  m_CullTransparentMesh: 1
 --- !u!114 &1235137767 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1748615501916967598, guid: 0d52ffd9c87ab484b88610c4acf5db24,
@@ -1981,22 +2671,22 @@ PrefabInstance:
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.20579392
+      value: -0.7512772
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.08769552
+      value: -0.6012348
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.89664197
+      value: 0.21253234
       objectReference: {fileID: 0}
     - target: {fileID: 3849934062868920522, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.38208845
+      value: -0.17008613
       objectReference: {fileID: 0}
     - target: {fileID: 3919916255551741050, guid: 5fbb7c7c8ec47e849afba1b658f3e07e,
         type: 3}
@@ -9604,6 +10294,10 @@ PrefabInstance:
         type: 3}
       insertIndex: 1
       addedObject: {fileID: 1276984445}
+    - targetCorrespondingSourceObject: {fileID: 8632740765308209879, guid: 9963fec33e379324db2affcb3f83332f,
+        type: 3}
+      insertIndex: 4
+      addedObject: {fileID: 247449955}
     - targetCorrespondingSourceObject: {fileID: 8632740765308209879, guid: 9963fec33e379324db2affcb3f83332f,
         type: 3}
       insertIndex: -1

--- a/Assets/Sprites/UI/Icons/Type=Back, Color=blue900, Size=large.png
+++ b/Assets/Sprites/UI/Icons/Type=Back, Color=blue900, Size=large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7cbce183bda87adc36d13a6a4380cf7783d5a35deffe4c440de9d1abfb4fffe
+size 721

--- a/Assets/Sprites/UI/Icons/Type=Back, Color=blue900, Size=large.png.meta
+++ b/Assets/Sprites/UI/Icons/Type=Back, Color=blue900, Size=large.png.meta
@@ -1,0 +1,127 @@
+fileFormatVersion: 2
+guid: 8823622c92314914bac137acff9e9adc
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 512
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/UI/Icons/Type=Back, Color=white, Size=large.png
+++ b/Assets/Sprites/UI/Icons/Type=Back, Color=white, Size=large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61ab08dbb3ecfa8b556d912da0cf1fdd46e14109195e33eeb903a1833efe8a53
+size 397

--- a/Assets/Sprites/UI/Icons/Type=Back, Color=white, Size=large.png.meta
+++ b/Assets/Sprites/UI/Icons/Type=Back, Color=white, Size=large.png.meta
@@ -1,0 +1,127 @@
+fileFormatVersion: 2
+guid: 8da33d9924087234bb277b7848a82d29
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 512
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/UI/Icons/Type=Next, Color=blue900, Size=large.png
+++ b/Assets/Sprites/UI/Icons/Type=Next, Color=blue900, Size=large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6501ecedacb09e8bdd8ec9a8ab90a253063e0d421c285a56fd0e7fb254aea5d2
+size 648

--- a/Assets/Sprites/UI/Icons/Type=Next, Color=blue900, Size=large.png.meta
+++ b/Assets/Sprites/UI/Icons/Type=Next, Color=blue900, Size=large.png.meta
@@ -1,0 +1,127 @@
+fileFormatVersion: 2
+guid: 25bca420df2197b46b2715c89cd10da9
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/UI/Icons/Type=Next, Color=white, Size=large.png
+++ b/Assets/Sprites/UI/Icons/Type=Next, Color=white, Size=large.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47003f1c25e1a8e55d1a37c3a5c6990d5e7e9097da7c5a9eccf46fc7c6ec7184
+size 408

--- a/Assets/Sprites/UI/Icons/Type=Next, Color=white, Size=large.png.meta
+++ b/Assets/Sprites/UI/Icons/Type=Next, Color=white, Size=large.png.meta
@@ -1,0 +1,127 @@
+fileFormatVersion: 2
+guid: 23706c506d5d87447aad32f673651b36
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Wat ik heb toegevoegd: 

In de main scene is er een extra UI sectie bijgekomen met de naam: ‘Secondary_Properties’ Hierin stop je de meest recente ‘Colorpicker.prefab’ (Er zit er al een in nu) 



Verder heb je de ColorSettings.Prefab nodig in het normale ‘Properties' Panel. 

Je zet de volgende items actief voor de terreinlagen: 'Kenmerk_Maaiveld’

Zodra je dan een maaiveldlaag aanklikt, dan open je de colorpicker in het secondary properties panel. 

Vergeet niet multiselect. Bij vragen, bel / app / slack maar!