### PR TITLE
Reset colors when importing mtl

### DIFF
--- a/Assets/Prefabs/UI/InspectorPanels/MTL_en_Textures/MTL_import.prefab
+++ b/Assets/Prefabs/UI/InspectorPanels/MTL_en_Textures/MTL_import.prefab
@@ -416,7 +416,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 603709164805375050}
         m_TargetAssemblyTypeName: Netherlands3D.Twin.MTLImportPropertySection, Assembly-CSharp
-        m_MethodName: ImportMTL
+        m_MethodName: ImportMtl
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2195,7 +2195,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 603709164805375050}
         m_TargetAssemblyTypeName: Netherlands3D.Twin.MTLImportPropertySection, Assembly-CSharp
-        m_MethodName: ImportMTL
+        m_MethodName: ImportMtl
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2697,7 +2697,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 603709164805375050}
         m_TargetAssemblyTypeName: Netherlands3D.Twin.MTLImportPropertySection, Assembly-CSharp
-        m_MethodName: ImportMTL
+        m_MethodName: ImportMtl
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Prefabs/UI/InspectorPanels/Schaduwstudie/Schaduwstudie.prefab
+++ b/Assets/Prefabs/UI/InspectorPanels/Schaduwstudie/Schaduwstudie.prefab
@@ -1764,7 +1764,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 603709164805375050}
         m_TargetAssemblyTypeName: Netherlands3D.Twin.MTLImportPropertySection, Assembly-CSharp
-        m_MethodName: ImportMTL
+        m_MethodName: ImportMtl
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/_Application/Layers/LayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerGameObject.cs
@@ -196,7 +196,7 @@ namespace Netherlands3D.Twin.Layers
 
         public virtual void ApplyStyling()
         {
-            //initialize the layer's style
+            //initialize the layer's style and emit an event for other services and/or UI to update
             OnStylingApplied.Invoke();
         }
 #endregion

--- a/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectLayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectLayerGameObject.cs
@@ -264,6 +264,8 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject
             {
                 HierarchicalObjectTileLayerStyler.Apply(this, GetStyling(feature), feature);
             }
+            
+            base.ApplyStyling();
         }
     }
 }

--- a/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectLayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectLayerGameObject.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Netherlands3D.Coordinates;
 using Netherlands3D.Services;
 using Netherlands3D.Twin.FloatingOrigin;
+using Netherlands3D.Twin.Layers.LayerTypes.CartesianTiles;
 using Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject.Properties;
 using Netherlands3D.Twin.Layers.LayerTypes.Polygons;
 using Netherlands3D.Twin.Layers.LayerTypes.Polygons.Properties;
@@ -251,65 +253,15 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject
 
         public override void ApplyStyling()
         {
+            // Dynamically create a list of Layer features because a different set of renderers could be present after
+            // an import or replacement.
             var features = CreateFeaturesByType<MeshRenderer>();
+            
+            // Apply style to the features that was discovered
             foreach (var feature in features)
             {
-                ApplyStyling(feature);
+                HierarchicalObjectTileLayerStyler.Apply(this, GetStyling(feature), feature);
             }
-        }
-
-        /// <summary>
-        /// Finds the styling for this feature and applies it.
-        ///
-        /// It is expected that the features for a HierarchicalObjectLayerGameObject are meshRenderers, if they are not
-        /// we do not know how to style that and we ignore that feature.
-        /// </summary>
-        private void ApplyStyling(LayerFeature feature)
-        {
-            if (feature.Geometry is not MeshRenderer meshRenderer) return;
-
-            var symbolizer = GetStyling(feature);
-            var fillColor = symbolizer.GetFillColor();
-
-            // Keep the original material color if fill color is not set (null)
-            if (!fillColor.HasValue) return;
-
-            LayerData.Color = fillColor.Value;
-            SetUrpLitColorOptimized(meshRenderer, fillColor.Value);
-        }
-
-        public void SetUrpLitColorOptimized(MeshRenderer renderer, Color color, int? materialIndex = null)
-        {
-            int BaseColor = Shader.PropertyToID("_BaseColor");
-            // If a material index was provided: manipulate the start and end to do a single iteration in the loop with
-            // this material index, otherwise we manipulate all
-            int startIndex = materialIndex.HasValue ? materialIndex.Value : 0;
-            int endIndex = materialIndex.HasValue ? materialIndex.Value : renderer.materials.Length - 1;
-
-            // Make sure to assign the color to each material in the meshrenderer
-            for (var index = startIndex; index <= endIndex; index++)
-            {
-                MaterialPropertyBlock block = new MaterialPropertyBlock();
-                renderer.GetPropertyBlock(block, index);
-                block.SetColor(BaseColor, color);
-                renderer.SetPropertyBlock(block, index);
-            }
-        }
-
-        /// <summary>
-        /// Will add additional attributes to a newly created feature.
-        ///
-        /// For this class, we only have a few:
-        ///
-        /// * "materials" (array of strings) - only provided when the feature contains a meshrenderer
-        /// </summary>
-        protected override LayerFeature AddAttributesToLayerFeature(LayerFeature feature)
-        {
-            if (feature.Geometry is not MeshRenderer meshRenderer) return feature;
-
-            feature.Attributes.Add("materials", string.Join(",", meshRenderer.materials.Select(m => m.name)));
-
-            return feature;
         }
     }
 }

--- a/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectLayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectLayerGameObject.cs
@@ -152,9 +152,9 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject
         {
             //Position and rotation changes are handled by the WorldTransform, but should be updated in the project data
             //todo: add a == and != operator to Coordinate.cs to avoid having to do this
-            if(WorldTransform.Coordinate.value1 != previousCoordinate.value1 ||
-               WorldTransform.Coordinate.value2 != previousCoordinate.value2 ||
-               WorldTransform.Coordinate.value3 != previousCoordinate.value3)
+            if(Math.Abs(WorldTransform.Coordinate.value1 - previousCoordinate.value1) > 0.0001d ||
+               Math.Abs(WorldTransform.Coordinate.value2 - previousCoordinate.value2) > 0.0001d ||
+               Math.Abs(WorldTransform.Coordinate.value3 - previousCoordinate.value3) > 0.0001d)
             {
                 transformPropertyData.Position = WorldTransform.Coordinate;
                 previousCoordinate = WorldTransform.Coordinate;
@@ -231,8 +231,10 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject
 
         public override void OnProxyTransformParentChanged()
         {
-            if (toggleScatterPropertySectionInstantiator.PropertySection != null)
-                toggleScatterPropertySectionInstantiator.PropertySection?.TogglePropertyToggle();
+            if (toggleScatterPropertySectionInstantiator.PropertySection)
+            {
+                toggleScatterPropertySectionInstantiator.PropertySection.TogglePropertyToggle();
+            }
         }
 
         public static ObjectScatterLayerGameObject ConvertToScatterLayer(HierarchicalObjectLayerGameObject objectLayerGameObject)

--- a/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectTileLayerStyler.cs
+++ b/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectTileLayerStyler.cs
@@ -39,6 +39,7 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.CartesianTiles
         public static void ResetColoring(HierarchicalObjectLayerGameObject layer)
         {
             SetColor(layer, null);
+            layer.ApplyStyling();
         }
 
         /// <summary>

--- a/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectTileLayerStyler.cs
+++ b/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectTileLayerStyler.cs
@@ -36,6 +36,11 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.CartesianTiles
             return layer.LayerData.DefaultStyle.AnyFeature.Symbolizer.GetFillColor();
         }
 
+        public static void ResetColoring(HierarchicalObjectLayerGameObject layer)
+        {
+            SetColor(layer, null);
+        }
+
         /// <summary>
         /// The other methods deal with manipulating the styles for a layerfeature, this method takes the outcome of
         /// those actions and applies them to the materials for the binary mesh layer.
@@ -52,7 +57,7 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.CartesianTiles
             layer.LayerData.Color = fillColor.Value;
             SetUrpLitColorOptimized(meshRenderer, fillColor.Value);
         }
-        
+
         private static void SetUrpLitColorOptimized(MeshRenderer renderer, Color color, int? materialIndex = null)
         {
             int BaseColor = Shader.PropertyToID("_BaseColor");

--- a/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectTileLayerStyler.cs
+++ b/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectTileLayerStyler.cs
@@ -1,0 +1,75 @@
+﻿using Netherlands3D.LayerStyles;
+using Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject;
+using UnityEngine;
+
+namespace Netherlands3D.Twin.Layers.LayerTypes.CartesianTiles
+{
+    /// <summary>
+    /// Helper class that helps with styling HierarchicalObject layers.
+    ///
+    /// Hierarchical Object layers can be styled by changing the color for a material - or set of layer features. This
+    /// class can provide helpers to ensure a consistent set of styling rules is made, and to manage them.  
+    /// </summary>
+    public static class HierarchicalObjectTileLayerStyler
+    {
+        /// <summary>
+        /// Sets a custom color for all layer features matching the material index of the given layer feature.
+        /// </summary>
+        public static void SetColor(HierarchicalObjectLayerGameObject layer, Color? color)
+        {
+            var symbolizer = layer.LayerData.DefaultStyle.AnyFeature.Symbolizer;
+            if (color.HasValue)
+            {
+                symbolizer.SetFillColor(color.Value);
+            }
+            else
+            {
+                symbolizer.ClearFillColor();
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the color for the current object.
+        /// </summary>
+        public static Color? GetColor(HierarchicalObjectLayerGameObject layer)
+        {
+            return layer.LayerData.DefaultStyle.AnyFeature.Symbolizer.GetFillColor();
+        }
+
+        /// <summary>
+        /// The other methods deal with manipulating the styles for a layerfeature, this method takes the outcome of
+        /// those actions and applies them to the materials for the binary mesh layer.
+        /// </summary>
+        public static void Apply(HierarchicalObjectLayerGameObject layer, Symbolizer styling, LayerFeature layerFeature)
+        {
+            if (layerFeature.Geometry is not MeshRenderer meshRenderer) return;
+
+            var fillColor = styling.GetFillColor();
+
+            // Keep the original material color if fill color is not set (null)
+            if (!fillColor.HasValue) return;
+
+            layer.LayerData.Color = fillColor.Value;
+            SetUrpLitColorOptimized(meshRenderer, fillColor.Value);
+        }
+        
+        private static void SetUrpLitColorOptimized(MeshRenderer renderer, Color color, int? materialIndex = null)
+        {
+            int BaseColor = Shader.PropertyToID("_BaseColor");
+
+            // If a material index was provided: manipulate the start and end to do a single iteration in the loop with
+            // this material index, otherwise we manipulate all
+            int startIndex = materialIndex.HasValue ? materialIndex.Value : 0;
+            int endIndex = materialIndex.HasValue ? materialIndex.Value : renderer.materials.Length - 1;
+
+            // Make sure to assign the color to each material in the meshrenderer
+            for (var index = startIndex; index <= endIndex; index++)
+            {
+                MaterialPropertyBlock block = new MaterialPropertyBlock();
+                renderer.GetPropertyBlock(block, index);
+                block.SetColor(BaseColor, color);
+                renderer.SetPropertyBlock(block, index);
+            }
+        }
+    }
+}

--- a/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectTileLayerStyler.cs.meta
+++ b/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectTileLayerStyler.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7201637f36044c68bebfb06e55e6da09
+timeCreated: 1748343817

--- a/Assets/_Application/Layers/Properties/CartesianTileLayerFeatureColorPropertySection.cs
+++ b/Assets/_Application/Layers/Properties/CartesianTileLayerFeatureColorPropertySection.cs
@@ -101,7 +101,7 @@ namespace Netherlands3D.Twin.Layers.Properties
         private void SelectSwatch(ColorSwatch swatch)
         {
             ShowColorPicker();
-            colorPicker.SetColorPickerColor(swatch.Color);
+            colorPicker.PickColorWithoutNotify(swatch.Color);
 
             swatch.SetSelected(true);
         }
@@ -137,11 +137,6 @@ namespace Netherlands3D.Twin.Layers.Properties
         private void SetColorizationStylingRule(LayerFeature layerFeature, Color color)
         {
             CartesianTileLayerStyler.SetColor(layer, layerFeature, color);
-        }
-
-        private static string ColorizationStyleRuleName(int materialIndexIdentifier)
-        {
-            return $"feature.{materialIndexIdentifier}.colorize";
         }
 
         private void UpdateSwatches()

--- a/Assets/_Application/Layers/Properties/ColorPickerPropertySection.cs
+++ b/Assets/_Application/Layers/Properties/ColorPickerPropertySection.cs
@@ -1,4 +1,5 @@
-using System;
+using Netherlands3D.Twin.Layers.LayerTypes.CartesianTiles;
+using Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject;
 using Netherlands3D.Twin.UI.ColorPicker;
 using UnityEngine;
 using UnityEngine.Events;
@@ -61,7 +62,10 @@ namespace Netherlands3D.Twin.Layers.Properties
         /// <param name="color"></param>
         private void OnPickDefaultFillColor(Color color)
         {
-            if (layer != null) layer.LayerData.DefaultStyle.AnyFeature.Symbolizer.SetFillColor(color);
+            if (layer is HierarchicalObjectLayerGameObject hierarchicalObjectLayerGameObject)
+            {
+                HierarchicalObjectTileLayerStyler.SetColor(hierarchicalObjectLayerGameObject, color);
+            }
         }
     }
 }

--- a/Assets/_Application/Layers/Properties/ColorPickerPropertySection.cs
+++ b/Assets/_Application/Layers/Properties/ColorPickerPropertySection.cs
@@ -10,42 +10,54 @@ namespace Netherlands3D.Twin.Layers.Properties
     {
         [SerializeField] private Color defaultColor = Color.white;
         [SerializeField] private ColorWheel colorPicker;
-        private LayerGameObject layer;
         public UnityEvent<Color> PickedColor = new();
+
+        private LayerGameObject layer;
 
         public override LayerGameObject LayerGameObject
         {
             get => layer;
-            set
-            {
-                layer = value;
-                colorPicker.SetColorWithoutNotify(layer.LayerData.DefaultStyle.AnyFeature.Symbolizer.GetFillColor().GetValueOrDefault(defaultColor));
-            }
+            set => ChangeLayerTo(value);
         }
 
         private void Awake()
         {
-            PickedColor.AddListener(OnPickDefaultFillColor);
+            PickedColor.AddListener(OnColorPicked);
         }
 
         private void OnDestroy()
         {
-            PickedColor.RemoveListener(OnPickDefaultFillColor);
-        }
-
-        public void SetColorPickerColor(Color color)
-        {
-            colorPicker.SetColorWithoutNotify(color);
+            PickedColor.RemoveListener(OnColorPicked);
         }
 
         private void OnEnable()
         {
             colorPicker.colorChanged.AddListener(OnPickedColor);
+            if (layer) layer.OnStylingApplied.AddListener(UpdateColorFromLayer);
         }
 
         private void OnDisable()
         {
             colorPicker.colorChanged.RemoveListener(OnPickedColor);
+            if (layer) layer.OnStylingApplied.RemoveListener(UpdateColorFromLayer);
+        }
+
+        public void PickColorWithoutNotify(Color color)
+        {
+            colorPicker.SetColorWithoutNotify(color);
+        }
+
+        /// <summary>
+        /// Since the layer may or may not be known on Awake/Start of this component, we need to remove and re-add
+        /// listeners on a layer when we set/replace it, and update the color in the color picker to that of the layer.
+        /// </summary>
+        private void ChangeLayerTo(LayerGameObject value)
+        {
+            if (layer && enabled) layer.OnStylingApplied.RemoveListener(UpdateColorFromLayer);
+            layer = value;
+            if (layer && enabled) layer.OnStylingApplied.AddListener(UpdateColorFromLayer);
+
+            UpdateColorFromLayer();
         }
 
         public void OnPickedColor(Color color)
@@ -54,13 +66,22 @@ namespace Netherlands3D.Twin.Layers.Properties
             layer.ApplyStyling();
         }
 
+        private void UpdateColorFromLayer()
+        {
+            if (layer is HierarchicalObjectLayerGameObject hierarchicalObjectLayerGameObject)
+            {
+                var color = HierarchicalObjectTileLayerStyler.GetColor(hierarchicalObjectLayerGameObject);
+                this.PickColorWithoutNotify(color.HasValue ? color.Value : defaultColor);
+            }
+        }
+
         /// <summary>
         /// Default behaviour is to set the picked color as the, unconditional, fill color for the given layer. This
         /// should suffice in most situations, but if a different behaviour is desired you can remove all listeners
         /// from the PickedColor event and provide your own implementation.
         /// </summary>
         /// <param name="color"></param>
-        private void OnPickDefaultFillColor(Color color)
+        private void OnColorPicked(Color color)
         {
             if (layer is HierarchicalObjectLayerGameObject hierarchicalObjectLayerGameObject)
             {

--- a/Assets/_Application/Layers/Properties/StrokeColorPropertySection.cs
+++ b/Assets/_Application/Layers/Properties/StrokeColorPropertySection.cs
@@ -1,4 +1,3 @@
-using Netherlands3D.LayerStyles;
 using Netherlands3D.Twin.UI.ColorPicker;
 using UnityEngine;
 

--- a/Assets/_BuildingBlocks/LayerStyles/Scripts/Symbolizer.cs
+++ b/Assets/_BuildingBlocks/LayerStyles/Scripts/Symbolizer.cs
@@ -26,6 +26,8 @@ namespace Netherlands3D.LayerStyles
         /// <link href="https://docs.mapbox.com/style-spec/reference/layers/#paint-fill-fill-color"/>
         public Color? GetFillColor() => GetAndNormalizeColor("fill-color");
 
+        public void ClearFillColor() => ClearProperty("fill-color");
+
         /// <link href="https://docs.mapbox.com/style-spec/reference/layers/#paint-line-line-color"/>
         /// <remarks>
         /// Originally, the implementation was based on OGC CartoSym, which uses the term "stroke-color"; because the
@@ -41,8 +43,11 @@ namespace Netherlands3D.LayerStyles
         /// the term Stroke Color instead of Mapbox' Line Color.
         /// </remarks>
         public Color? GetStrokeColor() => GetAndNormalizeColor("stroke-color");
-        #endregion
+
+        public void ClearStrokeColor() => ClearProperty("stroke-color");
         
+        #endregion
+
         /// <summary>
         /// Populates the given Symbolizer where the values of otherSymbolizer are merged on top of the values of it.
         ///
@@ -64,7 +69,7 @@ namespace Netherlands3D.LayerStyles
 
             return symbolizer;
         }
-        
+
         public override string ToString()
         {
             var result = "";
@@ -77,6 +82,7 @@ namespace Netherlands3D.LayerStyles
         }
 
         #region Getting and setting properties, and normalisation of object types from/to string
+
         private void SetAndNormalizeColor(string propertyName, Color color)
         {
             SetProperty(propertyName, $"#{ColorUtility.ToHtmlStringRGBA(color)}");
@@ -104,6 +110,16 @@ namespace Netherlands3D.LayerStyles
         {
             properties[key] = value;
         }
+
+        /// <summary>
+        /// When an override is no longer necessary, we should be able to clear it so that the it is no longer applied
+        /// next time styling is applied.
+        /// </summary>
+        private void ClearProperty(string propertyName)
+        {
+            properties.Remove(propertyName);
+        }
+
         #endregion
     }
 }

--- a/Assets/_Functionalities/ObjImporter/Prefabs/OBJLayer.prefab
+++ b/Assets/_Functionalities/ObjImporter/Prefabs/OBJLayer.prefab
@@ -52,6 +52,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   prefabIdentifier: 34882a73ff6122243a0e3e9811473e20
+  thumbnail: {fileID: 0}
+  spawnLocation: 0
+  OnStylingApplied:
+    m_PersistentCalls:
+      m_Calls: []
   onShow:
     m_PersistentCalls:
       m_Calls: []
@@ -94,7 +99,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   worldTransformShifter: {fileID: 8128677453936289607}
-  referenceCoordinateSystem: 2
   onPreShift:
     m_PersistentCalls:
       m_Calls: []
@@ -165,5 +169,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6303d72dc2aa4f61bcacd10f6b5e3e43, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  propertySectionPrefab: {fileID: 470222656515864098, guid: 0abb37c7616acf44dbafc477afb67932,
+  propertySectionPrefab: {fileID: 3414392683841753435, guid: c78b9cbfeb6b857479e94e59739d2347,
     type: 3}

--- a/Assets/_Functionalities/ObjImporter/Scripts/MTLImportPropertySection.cs
+++ b/Assets/_Functionalities/ObjImporter/Scripts/MTLImportPropertySection.cs
@@ -1,4 +1,5 @@
-using Netherlands3D.Twin.Layers;
+using Netherlands3D.Twin.Layers.LayerTypes.CartesianTiles;
+using Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject;
 using UnityEngine;
 
 namespace Netherlands3D.Functionalities.OBJImporter
@@ -8,20 +9,24 @@ namespace Netherlands3D.Functionalities.OBJImporter
         [SerializeField] private GameObject defaultImportPanel;
         [SerializeField] private GameObject hasMtlPanel;
         [SerializeField] private GameObject importErrorPanel;
+        private HierarchicalObjectLayerGameObject layer;
         public OBJSpawner ObjSpawner { get; set; }
         
         private void Start()
         {
+            layer = ObjSpawner.GetComponent<HierarchicalObjectLayerGameObject>();
             SetNormalUIPanels();
             ObjSpawner.MtlImportSuccess.AddListener(OnMTLImportError);
         }
 
         //called in the inspector by FileOpen.cs
-        public void ImportMTL(string path)
+        public void ImportMtl(string path)
         {
-            if (path.EndsWith(','))
-                path = path.Remove(path.Length - 1);
-            
+            path = path.TrimEnd(',');
+
+            // When importing an MTL - we want to reset the coloring of the object
+            HierarchicalObjectTileLayerStyler.ResetColoring(layer);
+
             ObjSpawner.SetMtlPathInPropertyData(path);
             ObjSpawner.StartImport();
             


### PR DESCRIPTION
In this PR, I have moved the logic for coloring obj's to a 'Styler' helper class, similar to what was done for the cartesian tiles, to make the API simpler to read. With this change, I can now also add a method for resetting the color, which is used when importing an MTL file.

During development I discovered that the wrong colorpicker was now used (Fill instead of 'regular'), and to simplify the coloring mechanics even further I am now using that. It responds to the event LayerStylingApplied to update the picked color in the colorwheel as the color is now externally influenced by the importing of the MTL.