### PR TITLE
coordinates in the grid tool UI now copy in X,Y order instead of Y,X

### DIFF
--- a/Assets/_Functionalities/AreaDownload/Scripts/UI/DownloadInspector.cs
+++ b/Assets/_Functionalities/AreaDownload/Scripts/UI/DownloadInspector.cs
@@ -93,7 +93,7 @@ namespace Netherlands3D.Functionalities.AreaDownload.UI
 
         private void CopySouthWestToClipboard()
         {
-            var text = $"{southExtentTextField.text},{westExtentTextField.text}";
+            var text = $"{westExtentTextField.text},{southExtentTextField.text}";
 #if UNITY_WEBGL && !UNITY_EDITOR
             CopyToClipboard(text);
 #else
@@ -103,7 +103,7 @@ namespace Netherlands3D.Functionalities.AreaDownload.UI
 
         private void CopyNorthEastToClipboard()
         {
-            var text = $"{northExtentTextField.text},{eastExtentTextField.text}";
+            var text = $"{eastExtentTextField.text},{northExtentTextField.text}";
 #if UNITY_WEBGL && !UNITY_EDITOR
             CopyToClipboard(text);
 #else


### PR DESCRIPTION
https://cdn-dev-ams-3da.azureedge.net/autobuild/fix/coordinate-copy-order/486699050/feature/