### PR TITLE
Feature/tygron improvements

### DIFF
--- a/Assets/Prefabs/UI/Layers/LayerUI.prefab
+++ b/Assets/Prefabs/UI/Layers/LayerUI.prefab
@@ -2090,6 +2090,7 @@ GameObject:
   - component: {fileID: 1244387766270603908}
   - component: {fileID: 2493342414096201978}
   - component: {fileID: 987838390540822561}
+  - component: {fileID: 8376791361315786068}
   m_Layer: 5
   m_Name: LayerUI
   m_TagString: Untagged
@@ -2229,6 +2230,23 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!114 &8376791361315786068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6053239577656790416}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
 --- !u!1 &6171282763605231320
 GameObject:
   m_ObjectHideFlags: 0
@@ -2838,6 +2856,7 @@ GameObject:
   - component: {fileID: 4825330292442188468}
   - component: {fileID: 8716488280504887416}
   - component: {fileID: 6890775580595209420}
+  - component: {fileID: 1294460613571645869}
   m_Layer: 5
   m_Name: Children
   m_TagString: Untagged
@@ -2951,6 +2970,23 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!114 &1294460613571645869
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7411352414403434503}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
 --- !u!1 &7659750204826595931
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/UI/Layers/LayerUI.prefab
+++ b/Assets/Prefabs/UI/Layers/LayerUI.prefab
@@ -2089,6 +2089,7 @@ GameObject:
   - component: {fileID: 2127760596796970168}
   - component: {fileID: 1244387766270603908}
   - component: {fileID: 2493342414096201978}
+  - component: {fileID: 987838390540822561}
   m_Layer: 5
   m_Name: LayerUI
   m_TagString: Untagged
@@ -2205,6 +2206,29 @@ MonoBehaviour:
   layerTypeImage: {fileID: 1356745287749164724}
   errorLayerTypeImage: {fileID: 94072058954664853}
   errorColor: {r: 0.8, g: 0.84313726, b: 0.89411765, a: 1}
+--- !u!223 &987838390540822561
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6053239577656790416}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
 --- !u!1 &6171282763605231320
 GameObject:
   m_ObjectHideFlags: 0
@@ -2813,6 +2837,7 @@ GameObject:
   - component: {fileID: 4836292693583781584}
   - component: {fileID: 4825330292442188468}
   - component: {fileID: 8716488280504887416}
+  - component: {fileID: 6890775580595209420}
   m_Layer: 5
   m_Name: Children
   m_TagString: Untagged
@@ -2903,6 +2928,29 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!223 &6890775580595209420
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7411352414403434503}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
 --- !u!1 &7659750204826595931
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Application/Layers/UI/HierarchyInspector/LayerUIManager.cs
+++ b/Assets/_Application/Layers/UI/HierarchyInspector/LayerUIManager.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Netherlands3D.Functionalities.OGC3DTiles;
@@ -34,6 +35,8 @@ namespace Netherlands3D.Twin.Layers.UI.HierarchyInspector
         public RectTransform DragLine => dragLine;
         public Vector2 DragStartOffset { get; set; }
         public bool MouseIsOverButton { get; set; }
+        
+        private LayerData layerToSelectAtEndOfFrame; //only select a layer once at the end of the frame in case multiple layers are made in this frame to avoid an unnecessary performance hit.
 
         private void ReconstructHierarchyUIs()
         {
@@ -104,7 +107,18 @@ namespace Netherlands3D.Twin.Layers.UI.HierarchyInspector
         {
             var layerUI = InstantiateLayerItem(layer, layer.ParentLayer);
             RecalculateLayersVisibleInInspector();
-            layer.SelectLayer(true);
+            
+            if(layerToSelectAtEndOfFrame == null)
+                StartCoroutine(SelectLayerAtEndOfFrame());
+    
+            layerToSelectAtEndOfFrame = layer;
+        }
+
+        private IEnumerator SelectLayerAtEndOfFrame()
+        {
+            yield return new WaitForEndOfFrame();
+            layerToSelectAtEndOfFrame.SelectLayer(true);
+            layerToSelectAtEndOfFrame = null;
         }
 
         private void OnRectTransformDimensionsChange()

--- a/Assets/_Functionalities/Wms/Materials/Decal.mat
+++ b/Assets/_Functionalities/Wms/Materials/Decal.mat
@@ -90,7 +90,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _Texture2D:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: 631097b184121456fb17de095dd0e917, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - unity_Lightmaps:
@@ -121,7 +121,7 @@ Material:
     - _DecalMeshViewBias: 0
     - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
-    - _DrawOrder: -2
+    - _DrawOrder: -6
     - _DstBlend: 0
     - _EnvironmentReflections: 1
     - _GlossMapScale: 0

--- a/Assets/_Functionalities/Wms/Materials/EmptyTexture.png
+++ b/Assets/_Functionalities/Wms/Materials/EmptyTexture.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:041dbe2f099c40e566074c4a866c71361a206b655c12f2a13a2ba55f2bfc6266
+size 4203

--- a/Assets/_Functionalities/Wms/Materials/EmptyTexture.png.meta
+++ b/Assets/_Functionalities/Wms/Materials/EmptyTexture.png.meta
@@ -1,0 +1,130 @@
+fileFormatVersion: 2
+guid: 631097b184121456fb17de095dd0e917
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 2
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Functionalities/Wms/Scripts/WMSImportAdapter.cs
+++ b/Assets/_Functionalities/Wms/Scripts/WMSImportAdapter.cs
@@ -92,9 +92,6 @@ namespace Netherlands3D.Functionalities.Wms
             {
                 CreateLayer(maps[i], url, wmsFolder, i < layerPrefab.DefaultEnabledLayersMax);
                 yield return null;
-                
-                // if(i > 10)
-                //     yield break;
             }
             Destroy(coroutineRunner);
         }

--- a/Assets/_Functionalities/Wms/Scripts/WMSImportAdapter.cs
+++ b/Assets/_Functionalities/Wms/Scripts/WMSImportAdapter.cs
@@ -91,8 +91,11 @@ namespace Netherlands3D.Functionalities.Wms
             for (int i = 0; i < maps.Count; i++)
             {
                 CreateLayer(maps[i], url, wmsFolder, i < layerPrefab.DefaultEnabledLayersMax);
-                yield return null;
+                
+                if (i % 10 == 0)
+                    yield return null;
             }
+
             Destroy(coroutineRunner);
         }
 

--- a/Assets/_Functionalities/Wms/Scripts/WMSImportAdapter.cs
+++ b/Assets/_Functionalities/Wms/Scripts/WMSImportAdapter.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using Netherlands3D.DataTypeAdapters;
 using Netherlands3D.OgcWebServices.Shared;
@@ -8,6 +10,10 @@ using UnityEngine;
 
 namespace Netherlands3D.Functionalities.Wms
 {
+    public class CoroutineRunner : MonoBehaviour
+    {
+    }
+
     [CreateAssetMenu(menuName = "Netherlands3D/Adapters/WMSImportAdapter", fileName = "WMSImportAdapter", order = 0)]
     public class WMSImportAdapter : ScriptableObject, IDataTypeAdapter
     {
@@ -56,10 +62,9 @@ namespace Netherlands3D.Functionalities.Wms
                     layerPrefab.PreferredImageSize.y,
                     layerPrefab.TransparencyEnabled
                 );
-                for (int i = 0; i < maps.Count; i++)
-                {
-                    CreateLayer(maps[i], url, wmsFolder, i < layerPrefab.DefaultEnabledLayersMax);
-                }
+                
+                var coroutineRunner = new GameObject("WMSImportAdapter coroutine runner").AddComponent<CoroutineRunner>();
+                coroutineRunner.StartCoroutine(CreateMapLayers(maps, url, wmsFolder, coroutineRunner.gameObject));
 
                 return;
             }
@@ -79,6 +84,19 @@ namespace Netherlands3D.Functionalities.Wms
             }
             
             Debug.LogError("Unrecognized WMS request type at " + url);
+        }
+
+        private IEnumerator CreateMapLayers(List<MapFilters> maps, Uri url, FolderLayer wmsFolder, GameObject coroutineRunner)
+        {
+            for (int i = 0; i < maps.Count; i++)
+            {
+                CreateLayer(maps[i], url, wmsFolder, i < layerPrefab.DefaultEnabledLayersMax);
+                yield return null;
+                
+                // if(i > 10)
+                //     yield break;
+            }
+            Destroy(coroutineRunner);
         }
 
         private void CreateLayer(MapFilters mapFilters, Uri url, FolderLayer folderLayer, bool defaultEnabled = true)

--- a/Assets/_Functionalities/Wms/Scripts/WMSImportAdapter.cs
+++ b/Assets/_Functionalities/Wms/Scripts/WMSImportAdapter.cs
@@ -84,6 +84,7 @@ namespace Netherlands3D.Functionalities.Wms
         private void CreateLayer(MapFilters mapFilters, Uri url, FolderLayer folderLayer, bool defaultEnabled = true)
         {
             WMSLayerGameObject newLayer = Instantiate(layerPrefab);
+            newLayer.gameObject.name = mapFilters.name;
             newLayer.LayerData.SetParent(folderLayer);
             newLayer.Name = mapFilters.name;
             newLayer.LayerData.ActiveSelf = defaultEnabled;

--- a/Assets/_Functionalities/Wms/Scripts/WMSLayerGameObject.cs
+++ b/Assets/_Functionalities/Wms/Scripts/WMSLayerGameObject.cs
@@ -97,7 +97,7 @@ namespace Netherlands3D.Functionalities.Wms
             WMSProjectionLayer.SetAuthorization(auth);
             LayerData.HasValidCredentials = true;
             WMSProjectionLayer.RefreshTiles();
-            WMSProjectionLayer.isEnabled = true;
+            WMSProjectionLayer.isEnabled = LayerData.ActiveInHierarchy;
         }
 
         public void ClearCredentials()

--- a/Assets/_Functionalities/Wms/Scripts/WMSTileDataLayer.cs
+++ b/Assets/_Functionalities/Wms/Scripts/WMSTileDataLayer.cs
@@ -79,6 +79,8 @@ namespace Netherlands3D.Functionalities.Wms
         
         protected override IEnumerator DownloadDataAndGenerateTexture(TileChange tileChange, Action<TileChange> callback = null)
         {
+            Debug.Log("downloading textrue for " + gameObject.name );
+
             var tileKey = new Vector2Int(tileChange.X, tileChange.Y);
 
             if (!tiles.ContainsKey(tileKey))

--- a/Assets/_Functionalities/Wms/Scripts/WMSTileDataLayer.cs
+++ b/Assets/_Functionalities/Wms/Scripts/WMSTileDataLayer.cs
@@ -79,8 +79,6 @@ namespace Netherlands3D.Functionalities.Wms
         
         protected override IEnumerator DownloadDataAndGenerateTexture(TileChange tileChange, Action<TileChange> callback = null)
         {
-            Debug.Log("downloading textrue for " + gameObject.name );
-
             var tileKey = new Vector2Int(tileChange.X, tileChange.Y);
 
             if (!tiles.ContainsKey(tileKey))

--- a/Assets/_Functionalities/Wms/Scripts/WMSTileDataLayer.cs
+++ b/Assets/_Functionalities/Wms/Scripts/WMSTileDataLayer.cs
@@ -54,7 +54,7 @@ namespace Netherlands3D.Functionalities.Wms
             {
                 var baseDataset = new DataSet()
                 {
-                    maximumDistance = 3000,
+                    maximumDistance = 6000,
                     maximumDistanceSquared = 1000 * 1000
                 };
                 Datasets.Add(baseDataset);

--- a/Assets/_Functionalities/Wms/Scripts/WMSTileDataLayer.cs
+++ b/Assets/_Functionalities/Wms/Scripts/WMSTileDataLayer.cs
@@ -102,11 +102,7 @@ namespace Netherlands3D.Functionalities.Wms
                     ClearPreviousTexture(tile);
                     Texture2D tex = response.Data as Texture2D;
                     
-                    byte[] rawBytes = tex.GetRawTextureData();
-                    var hash = MD5.Create().ComputeHash(rawBytes);
-                    var hashString = Convert.ToBase64String(hash);
-                    
-                    if (hashString == emptyTextureHash || !tile.gameObject.TryGetComponent<TextureProjectorBase>(out var projector))
+                    if (!tile.gameObject.TryGetComponent<TextureProjectorBase>(out var projector))
                     {
                         Destroy(tex);
                         return;

--- a/Assets/_Functionalities/Wms/Scripts/WMSTileDataLayer.cs
+++ b/Assets/_Functionalities/Wms/Scripts/WMSTileDataLayer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using KindMen.Uxios;
 using Netherlands3D.CartesianTiles;
 using Netherlands3D.Coordinates;
@@ -15,7 +14,6 @@ namespace Netherlands3D.Functionalities.Wms
     public class WMSTileDataLayer : ImageProjectionLayer
     {
         private const string DefaultEpsgCoordinateSystem = "28992";
-        private const string emptyTextureHash = "Y4odUVJg31z7zQBWRvZ9jQ==";
 
         private Config requestConfig { get; set; } = new Config()
         {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -32,7 +32,7 @@
     "eu.netherlands3d.selection-tools": "2.8.0",
     "eu.netherlands3d.simplejson": "1.0.0",
     "eu.netherlands3d.snapshots": "2.0.0",
-    "eu.netherlands3d.subobjects": "1.4.0",
+    "eu.netherlands3d.subobjects": "1.4.1",
     "eu.netherlands3d.sun": "1.4.1",
     "eu.netherlands3d.tiles3d": "2.0.0",
     "eu.netherlands3d.transform-handles": "1.1.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -508,7 +508,7 @@
       "url": "https://package.openupm.com"
     },
     "eu.netherlands3d.subobjects": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {},


### PR DESCRIPTION
- added exception handling for incorrect json to the 3d tile import adapter
- increased max distance wms loads so the edges are covered
- fixed white wms textures when downloading empty texture
- Added optimization when adding multiple layers at once so that a SelectLayer action is only called once at the end of that frame
- LayerUI now has separate canvasses for optimization
- WMS layers are now added 10 layers per frame at a time to avoid the app from blocking too much
- Disabled WMS layers no longer inadvertently download their tile textures
- Updated subobjects package with a minor optimization 

https://cdn-dev-ams-3da.azureedge.net/autobuild/feature/tygron-improvements/2006446956/feature/