### PR TITLE
ondergrond shadowcatcher uit

### DIFF
--- a/Assets/Materials/Layers/Twin_Ondergrond.mat
+++ b/Assets/Materials/Layers/Twin_Ondergrond.mat
@@ -26,13 +26,15 @@ Material:
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
+  - _RECEIVE_SHADOWS_OFF
   - _TEXTURINGMODE_USE_WORLD_SPACE_UV
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
+  m_CustomRenderQueue: 2000
+  stringTagMap:
+    RenderType: Opaque
   disabledShaderPasses:
   - MOTIONVECTORS
   m_LockedProperties: 
@@ -111,8 +113,11 @@ Material:
     m_Floats:
     - Normal_Blend: 0.5
     - _AlphaClip: 0
+    - _AlphaToMask: 0
     - _Blend: 0
+    - _BlendModePreserveSpecular: 1
     - _BumpScale: 1
+    - _CastShadows: 1
     - _Cull: 2
     - _Cutoff: 0.5
     - _DecalMeshBiasType: 0
@@ -120,6 +125,7 @@ Material:
     - _DecalMeshViewBias: 0
     - _DrawOrder: 0
     - _DstBlend: 0
+    - _DstBlendAlpha: 0
     - _EnvironmentReflections: 1
     - _GlossMapScale: 0
     - _Glossiness: 0
@@ -130,7 +136,7 @@ Material:
     - _OcclusionStrength: 1
     - _QueueControl: 0
     - _QueueOffset: 0
-    - _ReceiveShadows: 1
+    - _ReceiveShadows: 0
     - _SPIKE_CLAMPING: 0
     - _SPIKE_FILTERING: 0
     - _SUBOBJECT_FILTERING: 0
@@ -139,10 +145,13 @@ Material:
     - _SpecularHighlights: 1
     - _SpikeClampHeight: 320
     - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
     - _Surface: 0
     - _TEXTURINGMODE: 1
     - _WorkflowMode: 1
+    - _ZTest: 4
     - _ZWrite: 1
+    - _ZWriteControl: 0
     m_Colors:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _ClippingMask: {r: 3.4028235e+38, g: 3.4028235e+38, b: 3.4028235e+38, a: 3.4028235e+38}

--- a/Assets/Prefabs/StandardLayers/Ground.prefab
+++ b/Assets/Prefabs/StandardLayers/Ground.prefab
@@ -105,6 +105,8 @@ MeshRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -126,9 +128,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &6074292130841963842
 MonoBehaviour:

--- a/Assets/Shaders/Twin_MainLayers.shadergraph
+++ b/Assets/Shaders/Twin_MainLayers.shadergraph
@@ -5020,7 +5020,7 @@
     "m_ActiveSubTarget": {
         "m_Id": "dc729e6434a747e3b3d3c3d17e075efb"
     },
-    "m_AllowMaterialOverride": false,
+    "m_AllowMaterialOverride": true,
     "m_SurfaceType": 0,
     "m_ZTestMode": 4,
     "m_ZWriteControl": 0,


### PR DESCRIPTION
Ik heb in de shader aangezet dat je de shadowcatching kan aanpassen binnen een materiaal en deze op de Ondergrond uitgezet zodat er geen schaduw op de ondergrond valt.