### PR TITLE
Added tooltip component

### DIFF
--- a/Assets/UI Toolkit/Resources/UI/Components/Tooltip-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/Tooltip-style.uss
@@ -11,11 +11,11 @@
     border-color: var(--color-blue-100);
     border-radius: var(--border-radius-sm);
 
-    display: none; /* standard on none so it only displays when set active*/
+    display: flex; 
 }
 
-.tooltip.active {
-    display: flex;
+.tooltip.hidden { /* uses utility script */
+    display: none;
 }
 
 .tooltip__label {

--- a/Assets/UI Toolkit/Resources/UI/Components/Tooltip-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/Tooltip-style.uss
@@ -1,0 +1,23 @@
+.tooltip {
+    min-height: var(--spacing-7);
+    min-width: var(--spacing-10);
+    padding-top: var(--spacing-1);
+    padding-right: var(--spacing-2);
+    padding-bottom: var(--spacing-1);
+    padding-left: var(--spacing-2);
+    align-self: flex-start;
+    background-color: var(--color-white);
+    border-width: var(--spacing-0_5);
+    border-color: var(--color-blue-100);
+    border-radius: var(--border-radius-sm);
+
+    display: none; /* standard on none so it only displays when set active*/
+}
+
+.tooltip.active {
+    display: flex;
+}
+
+.tooltip__label {
+    white-space: normal;
+}

--- a/Assets/UI Toolkit/Resources/UI/Components/Tooltip-style.uss.meta
+++ b/Assets/UI Toolkit/Resources/UI/Components/Tooltip-style.uss.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: c1ac255aa1ae7b443887178616fdd6ca
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0
+  unsupportedSelectorAction: 0

--- a/Assets/UI Toolkit/Resources/UI/Components/Tooltip.uxml
+++ b/Assets/UI Toolkit/Resources/UI/Components/Tooltip.uxml
@@ -1,0 +1,7 @@
+<ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:ui="UnityEngine.UIElements"
+         xmlns:uie="UnityEditor.UIElements"
+         noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd"
+>
+    <ui:Label name="Label" class="tooltip__label text-base" text="Tooltip" />
+</ui:UXML>

--- a/Assets/UI Toolkit/Resources/UI/Components/Tooltip.uxml
+++ b/Assets/UI Toolkit/Resources/UI/Components/Tooltip.uxml
@@ -2,6 +2,7 @@
          xmlns:ui="UnityEngine.UIElements"
          xmlns:uie="UnityEditor.UIElements"
          noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd"
+         class="tooltip"
 >
     <ui:Label name="Label" class="tooltip__label text-base" text="Tooltip" />
 </ui:UXML>

--- a/Assets/UI Toolkit/Resources/UI/Components/Tooltip.uxml.meta
+++ b/Assets/UI Toolkit/Resources/UI/Components/Tooltip.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: bf854b918bf320647806dc8e51c17e83
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/UI Toolkit/Resources/UI/TestSheet.uxml
+++ b/Assets/UI Toolkit/Resources/UI/TestSheet.uxml
@@ -7,7 +7,7 @@
                     <ui:Label text="Hover over dit element om je cursor te veranderen"/>
                 </Netherlands3D.UI.Components.ChangePointerStyleElement>
                 <Netherlands3D.UI.Components.Hyperlink text="website" url="https://netherlands3d.eu" tooltip="website"/>
-                <Netherlands3D.UI.Components.Tooltip style="display: flex;"/>
+                <Netherlands3D.UI.Components.Tooltip/>
                 <Netherlands3D.UI.Components.Breadcrumb/>
                 <Netherlands3D.UI.Components.IconButton/>
                 <Netherlands3D.UI.Components.BackButton/>

--- a/Assets/UI Toolkit/Resources/UI/TestSheet.uxml
+++ b/Assets/UI Toolkit/Resources/UI/TestSheet.uxml
@@ -4,9 +4,10 @@
         <Netherlands3D.UI.Components.ContentContainer>
             <Netherlands3D.UI.Components.ScrollView>
                 <Netherlands3D.UI.Components.ChangePointerStyleElement pointer-style-hover="Pointer">
-                    <ui:Label text="Hover over dit element om je cursor te veranderen" />
+                    <ui:Label text="Hover over dit element om je cursor te veranderen"/>
                 </Netherlands3D.UI.Components.ChangePointerStyleElement>
-                <Netherlands3D.UI.Components.Hyperlink text="website" url="https://netherlands3d.eu" />
+                <Netherlands3D.UI.Components.Hyperlink text="website" url="https://netherlands3d.eu" tooltip="website"/>
+                <Netherlands3D.UI.Components.Tooltip style="display: flex;"/>
                 <Netherlands3D.UI.Components.Breadcrumb/>
                 <Netherlands3D.UI.Components.IconButton/>
                 <Netherlands3D.UI.Components.BackButton/>

--- a/Assets/UI Toolkit/Scripts/Behaviours/ContextMenuBehaviour.cs
+++ b/Assets/UI Toolkit/Scripts/Behaviours/ContextMenuBehaviour.cs
@@ -27,7 +27,6 @@ namespace Netherlands3D.UI.Panels
             floatingPanel = new FloatingPanel();
             root.Add(floatingPanel);
             floatingPanel.OnClose.AddListener(ClearActivePanel);
-            floatingPanel.SetEnabled(false);
             var map = inputActionAsset.FindActionMap("Camera", true);
             rightClickAction = map.FindAction("RightClick", true);
             leftClickAction = map.FindAction("LeftClick", true);

--- a/Assets/UI Toolkit/Scripts/Components/Tooltip.cs
+++ b/Assets/UI Toolkit/Scripts/Components/Tooltip.cs
@@ -1,0 +1,42 @@
+using Netherlands3D.UI.ExtensionMethods;
+using Netherlands3D.UI_Toolkit.Scripts;
+using UnityEngine.UIElements;
+
+namespace Netherlands3D.UI.Components
+{
+    [UxmlElement]
+    public partial class Tooltip : VisualElement
+    {
+        private Label labelField;
+        private Label Label => labelField ??= this.Q<Label>("Label");
+
+        [UxmlAttribute("text")]
+        public string Text
+        {
+            get => Label?.text;
+            set
+            {
+                if (Label != null)
+                    Label.text = value;
+            }
+        }
+
+        public Tooltip()
+        {
+            this.CloneComponentTree("Components");
+            this.AddComponentStylesheet("Components");
+
+            AddToClassList("tooltip");
+        }
+
+        public void Show()
+        {
+            EnableInClassList("active", true);
+        }
+
+        public void Hide()
+        {
+            EnableInClassList("active", false);
+        }
+    }
+}

--- a/Assets/UI Toolkit/Scripts/Components/Tooltip.cs
+++ b/Assets/UI Toolkit/Scripts/Components/Tooltip.cs
@@ -1,5 +1,6 @@
 using Netherlands3D.UI.ExtensionMethods;
 using Netherlands3D.UI_Toolkit.Scripts;
+using Netherlands3D.UI_Toolkit;
 using UnityEngine.UIElements;
 
 namespace Netherlands3D.UI.Components
@@ -13,30 +14,14 @@ namespace Netherlands3D.UI.Components
         [UxmlAttribute("text")]
         public string Text
         {
-            get => Label?.text;
-            set
-            {
-                if (Label != null)
-                    Label.text = value;
-            }
+            get => Label.text;
+            set => Label.text = value;
         }
 
         public Tooltip()
         {
             this.CloneComponentTree("Components");
             this.AddComponentStylesheet("Components");
-
-            AddToClassList("tooltip");
-        }
-
-        public void Show()
-        {
-            EnableInClassList("active", true);
-        }
-
-        public void Hide()
-        {
-            EnableInClassList("active", false);
         }
     }
 }

--- a/Assets/UI Toolkit/Scripts/Components/Tooltip.cs
+++ b/Assets/UI Toolkit/Scripts/Components/Tooltip.cs
@@ -22,6 +22,13 @@ namespace Netherlands3D.UI.Components
         {
             this.CloneComponentTree("Components");
             this.AddComponentStylesheet("Components");
+            
+            Show(false);
+        }
+        
+        public void Show(bool show)
+        {
+            EnableInClassList(UtilityClassConstants.HIDDEN, !show);
         }
     }
 }

--- a/Assets/UI Toolkit/Scripts/Components/Tooltip.cs.meta
+++ b/Assets/UI Toolkit/Scripts/Components/Tooltip.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 061b6d890e9f42a41a3ce38cbc970c19


### PR DESCRIPTION
Added a Tooltip component. By default, it uses display: none. Added an active class to control visibility via the display property.

Note: This component is not connected to the UI Toolkit tooltip property or TooltipEvent. Those are Editor-only and are therefore not suitable for the runtime viewer. See the Unity documentation https://docs.unity3d.com/6000.3/Documentation/Manual/UIE-Tooltip-Events.html