### PR TITLE
snelle vastloper na inladen 3D BAG via 3D Tiles

### DIFF
--- a/Packages/eu.netherlands3d.tiles3d/Runtime/Scripts/Tileset/WebTilePrioritiser.cs
+++ b/Packages/eu.netherlands3d.tiles3d/Runtime/Scripts/Tileset/WebTilePrioritiser.cs
@@ -97,8 +97,11 @@ namespace Netherlands3D.Tiles3D
                     anyChildLoading = true;
                 }
             }
-
-            if(anyChildLoading && immediately==false)
+            if(tile.isLoading==true)
+            {
+                delayedDisposeList.Add(tile);
+            }
+            else if(anyChildLoading && immediately==false)
             {
                 delayedDisposeList.Add(tile);
             }


### PR DESCRIPTION
in webtileprioritiser.cs

the dispose-function does some checks to see if the tile can be deleted immediately, or if we have to wait for some reason. (for example if not all the replacing tiles alre loaded yet,to prevent holes in the loaded dataset)

adding a test to check if the tile itself is fully loaded prevents the tile form being destroyed while the geometry is still downloading, (wich was probably the cause for the errors)