### PR TITLE
Move default text wrapping to Foundation and remove duplicated local …

### DIFF
--- a/Assets/UI Toolkit/Resources/UI/Components/Button-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/Button-style.uss
@@ -49,7 +49,6 @@
 }
 
 .button > #Label { 
-    white-space: normal; 
     padding: 0px;
     margin: 0px;
 }

--- a/Assets/UI Toolkit/Resources/UI/Components/CheckboxToggle-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/CheckboxToggle-style.uss
@@ -45,7 +45,6 @@
     justify-content: flex-start;
     align-self: flex-start;
     min-width: 0;
-    white-space: normal; 
 }
 
 .checkbox-toggle.checkbox-position-right {

--- a/Assets/UI Toolkit/Resources/UI/Components/Footer-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/Footer-style.uss
@@ -48,5 +48,4 @@
     min-width: 0;
     margin: 0;
     padding: 0;
-    white-space: normal; 
 }

--- a/Assets/UI Toolkit/Resources/UI/Components/LayerTreeViewItem-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/LayerTreeViewItem-style.uss
@@ -34,6 +34,11 @@
     overflow: hidden;
 }
 
+.layer-tree-view-item__name-label .editable-name-field__label,
+.layer-tree-view-item__name-label .editable-name-field__input TextElement {
+    white-space: pre;
+}
+
 .unity-tree-view__item .layer-tree-view-item__property-toggle{
     padding: 0 var(--spacing-1) 0 var(--spacing-1);
     background-color: transparent;

--- a/Assets/UI Toolkit/Resources/UI/Components/RadioButtonGroup-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/RadioButtonGroup-style.uss
@@ -10,7 +10,6 @@
     margin-right: 0px;
     margin-bottom: var(--spacing-3);
     padding: 0px;
-    white-space: normal;
 }
 
 .radio-group .unity-radio-button__text {
@@ -19,7 +18,6 @@
     margin: 0px;
     padding: 0px;
     min-width: 0;
-    white-space: normal;
 }
 
 .radio-group .unity-radio-button {

--- a/Assets/UI Toolkit/Resources/UI/Components/SimulationSpeedControls-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/SimulationSpeedControls-style.uss
@@ -5,7 +5,6 @@
 .simulation-speed-controls__field-label {
     width: var(--spacing-20);
     flex-shrink: 0;
-    white-space: normal;
     -unity-text-align: middle-left;
     margin-right: var(--spacing-3);
 }

--- a/Assets/UI Toolkit/Resources/UI/Components/SliderBase-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/SliderBase-style.uss
@@ -11,7 +11,6 @@
 
 .unity-base-field__label {
     margin-bottom: var(--spacing-3);
-    white-space: normal;
 }
 
 .slider.slider-header-no-header > .unity-base-field__label,

--- a/Assets/UI Toolkit/Resources/UI/Components/TextCallOut-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/TextCallOut-style.uss
@@ -11,5 +11,4 @@
 }
 
 .textcallout > #Label {
-    white-space: normal;
 }

--- a/Assets/UI Toolkit/Resources/UI/Components/TextField-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/TextField-style.uss
@@ -53,7 +53,6 @@
 }
 
 .textfield TextElement {
-    white-space: normal;
     overflow: hidden;
     padding: 0;
 }

--- a/Assets/UI Toolkit/Resources/UI/Components/Toggle-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/Toggle-style.uss
@@ -51,7 +51,6 @@
 }
 
 .toggle > #Label { 
-    white-space: normal; 
     padding: 0px;
     margin: 0px;
 }

--- a/Assets/UI Toolkit/Resources/UI/Components/Tooltip-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/Tooltip-style.uss
@@ -19,5 +19,4 @@
 }
 
 .tooltip__label {
-    white-space: normal;
 }

--- a/Assets/UI Toolkit/Resources/UI/Panels/CredentialPanel-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/CredentialPanel-style.uss
@@ -41,7 +41,6 @@
     -unity-text-align: middle-left;
     margin: 0;
     padding: 0;
-    white-space: normal;
     margin-left: var(--spacing-2);
 }
 
@@ -63,7 +62,6 @@
     -unity-text-align: middle-left;
     margin: 0;
     padding: 0;
-    white-space: normal;
 }
 
 .credential-panel__input-field {

--- a/Assets/UI Toolkit/Resources/UI/Panels/ErrorPanelContent-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/ErrorPanelContent-style.uss
@@ -16,7 +16,6 @@
     -unity-text-align: middle-left;
     margin-left: var(--spacing-2);
     padding: 0;
-    white-space: normal;
 }
 
 .error-panel__message {
@@ -33,5 +32,4 @@
     -unity-text-align: middle-left;
     margin: 0;
     padding: 0;
-    white-space: normal;
 }

--- a/Assets/UI Toolkit/Resources/UI/Panels/HideObjectPanel-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/HideObjectPanel-style.uss
@@ -47,7 +47,6 @@
     -unity-text-align: middle-left;
     margin: 0;
     padding: 0;
-    white-space: normal;
 }
 
 .hide-object-panel__body {

--- a/Assets/UI Toolkit/Resources/UI/Panels/InspectorPolygonGridPanel-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/InspectorPolygonGridPanel-style.uss
@@ -26,7 +26,6 @@
 }
 
 .inspector-polygon-grid__body-tip-text{
-    white-space: pre-wrap;
 }
 
 .inspector-polygon-grid__number-fields-row{

--- a/Assets/UI Toolkit/Resources/UI/Panels/MTLImportPropertySection-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/MTLImportPropertySection-style.uss
@@ -1,5 +1,4 @@
 .mtl-property-section__text{
-    white-space: pre-wrap;
 }
 
 .mtl-property-section__button{

--- a/Assets/UI Toolkit/Resources/UI/Panels/MaskingPanel-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/MaskingPanel-style.uss
@@ -10,7 +10,6 @@
     -unity-text-align: middle-left;
     margin: 0;
     padding: 0;
-    white-space: normal;
 }
 
 .masking-panel__body {

--- a/Assets/UI Toolkit/Resources/UI/Panels/PolygonMaskingPropertySection-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/PolygonMaskingPropertySection-style.uss
@@ -3,5 +3,4 @@
 }
 
 .polygon-mask-property-section__message-text{
-    white-space: pre-wrap;
 }

--- a/Assets/UI Toolkit/Resources/UI/Panels/PolygonPropertySection-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/PolygonPropertySection-style.uss
@@ -3,7 +3,6 @@
 }
 
 .polygon-property-section__message-text{
-    white-space: pre-wrap;
 }
 
 .polygon-property-section__button{

--- a/Assets/UI Toolkit/Resources/UI/Panels/SnackbarPanel-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/SnackbarPanel-style.uss
@@ -13,6 +13,5 @@
 
 .snackbar-text
 {
-    white-space: normal;
     -unity-text-align: middle-center;
 }

--- a/Assets/UI Toolkit/Resources/UI/Panels/SunTimePanel-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/SunTimePanel-style.uss
@@ -23,7 +23,6 @@
     width: var(--sun-time-label-width);
     margin-right: var(--sun-time-label-spacing);
     flex-shrink: 0;
-    white-space: normal;
     -unity-text-align: middle-left;
 }
 

--- a/Assets/UI Toolkit/Resources/UI/Panels/VerticalDatumPropertySection-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/VerticalDatumPropertySection-style.uss
@@ -1,3 +1,2 @@
 .vertical-datum-property-section__text{
-    white-space: pre-wrap;
 }

--- a/Assets/UI Toolkit/Resources/UI/_Foundation.uss
+++ b/Assets/UI Toolkit/Resources/UI/_Foundation.uss
@@ -10,6 +10,10 @@
     display: none;
 }
 
+.text-wrapping {
+    white-space: normal;
+}
+
 .text-base, 
 .unity-label, 
 .text-header {
@@ -17,10 +21,12 @@
     font-size: var(--font-size-base);
     -unity-font-style: normal;
     color: var(--color-text);
+    white-space: normal;
 }
 
 .text-header {
     -unity-font-definition: var(--nl3d-header-font);
+    white-space: normal;
 }
 
 .inspector-header-title {
@@ -28,6 +34,7 @@
     font-size: var(--font-size-lg);
     -unity-font-style: normal;
     color: var(--color-text);
+    white-space: normal;
 }
 
 .vignette-edge {


### PR DESCRIPTION
…white-space: normal rules

Added a shared .text-wrapping utility in _Foundation.uss. Applied default white-space: normal to the shared text selectors in foundation. Removed duplicated white-space: normal declarations from panel/component USS files. Added a scoped white-space: pre override for layer tree EditableNameField labels and edit text.

- Check if different text types still show as intended (layers, buttons, headers, text fields etc.)
- Check if components that used pre-wrap style work properly with new default wrap.

InspectorPolygonGridPanel-style.uss
PolygonMaskingPropertySection-style.uss
MTLImportPropertySection-style.uss
PolygonPropertySection-style.uss
VerticalDatumPropertySection-style.uss

Keep pre-wrap in KeyValue-style.uss to avoid value changes from source data.