### PR TITLE
removed runtimeActive variable from Tools as this was not reliable. A…

### DIFF
--- a/Assets/_Application/Services/ToolService.cs
+++ b/Assets/_Application/Services/ToolService.cs
@@ -51,6 +51,30 @@ namespace Netherlands3D
         
         public UnityEvent AnyToolOpened;
         public UnityEvent AnyToolClosed;
+        
+#if UNITY_EDITOR
+        private Dictionary<Tool, bool> initialStates = new Dictionary<Tool, bool>();
+
+        public void OnValidate()
+        {
+            foreach (var entry in tools)
+            {
+                initialStates.Add(entry.tool, entry.tool.IsOpen);
+            }
+        }
+
+        private void OnApplicationQuit()
+        {
+            foreach (var entry in tools)
+            {
+                var initialOpen = initialStates[entry.tool];
+                if (initialOpen)
+                    entry.tool.Open();
+                else
+                    entry.tool.Close();
+            }
+        }
+#endif
 
         private void OnEnable()
         {

--- a/Assets/_Application/Tools/Tool.cs
+++ b/Assets/_Application/Tools/Tool.cs
@@ -46,10 +46,7 @@ namespace Netherlands3D.Twin.Tools
         }
 
         private GameObject[] functionalityInstances;
-
-        // Runtime configuration to prevent SO changes in editor
-        private bool runtimeOpen = false;
-
+        
         // Configuration setting, this way you can preconfigure the state of the tool
         [SerializeField] private bool open = false;
 
@@ -57,20 +54,14 @@ namespace Netherlands3D.Twin.Tools
 
         public bool IsOpen
         {
-            get => runtimeOpen;
-            private set => runtimeOpen = value;
+            get => open;
+            private set => open = value;
         }
 
         public bool Available
         {
             get => available;
             set => available = value;
-        }
-
-        //we have to force a sync with open, to be sure runtime open starts with the right value
-        private void OnEnable()
-        {
-            runtimeOpen = open;
         }
 
         /// <summary>


### PR DESCRIPTION
…dded a initial state tracker to the ToolService to reset the initial state after quitting the application