### PR TITLE
Add scenario update

### DIFF
--- a/Assets/Sprites/UI/Icons/Type=Scenario, Color=white, Size=medium.png
+++ b/Assets/Sprites/UI/Icons/Type=Scenario, Color=white, Size=medium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e070c33aa80c82e766dc5b2da02b23d9914e8b88d39a99c92238cabdbb46f0d4
+size 374

--- a/Assets/Sprites/UI/Icons/Type=Scenario, Color=white, Size=medium.png.meta
+++ b/Assets/Sprites/UI/Icons/Type=Scenario, Color=white, Size=medium.png.meta
@@ -1,0 +1,169 @@
+fileFormatVersion: 2
+guid: ace2a968d4ee66c46a6c84f421417910
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: iOS
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WindowsStoreApps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    customData: 
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI Toolkit/Resources/UI/Components/Icon-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/Icon-style.uss
@@ -111,6 +111,7 @@
 .icon.image-scale-v-1 { background-image: var(--icon-scalev1); }
 .icon.image-scale-v-2 { background-image: var(--icon-scalev2); }
 .icon.image-scatter-object { background-image: var(--icon-scatterobject); }
+.icon.image-scenario { background-image: var(--icon-scenario); }
 .icon.image-search { background-image: var(--icon-search); }
 .icon.image-section { background-image: var(--icon-section); }
 .icon.image-selection-box { background-image: var(--icon-selectionbox); }

--- a/Assets/UI Toolkit/Resources/UI/Panels/LayerPanel.uxml
+++ b/Assets/UI Toolkit/Resources/UI/Panels/LayerPanel.uxml
@@ -1,6 +1,7 @@
 <ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:nl3d="Netherlands3D.UI.Components" xmlns:nl3dP="Netherlands3D.UI.Panels" noNamespaceSchemaLocation="../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False" name="LayerPanel" class="layer-panel">
     <nl3d:TreeView/>
     <ui:VisualElement class="layer-panel__bottom-button-container">
+        <nl3d:Button name="ScenarioButton" button-style="IconOnly" icon="Scenario" tooltip="Nieuw scenario toevoegen"/>
         <nl3d:Button name="FolderButton" button-style="IconOnly" icon="Folder" tooltip="Voeg folder toe"/>
         <nl3d:Button name="DeleteButton" button-style="IconOnly" icon="Trash" tooltip="Verwijder geselecteerde laag"/>
     </ui:VisualElement>

--- a/Assets/UI Toolkit/Resources/UI/Panels/ScenarioPropertySection-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/ScenarioPropertySection-style.uss
@@ -1,0 +1,14 @@
+.scenario-property-section__explanation {
+    margin-top: var(--spacing-3);
+    padding: var(--spacing-3);
+    background-color: var(--color-blue-50);
+    border-radius: var(--border-radius-md);
+}
+
+.scenario-property-section__explanation .unity-label {
+    white-space: normal;
+}
+
+.scenario-property-section__tip {
+    margin-top: var(--spacing-4);
+}

--- a/Assets/UI Toolkit/Resources/UI/Panels/ScenarioPropertySection-style.uss.meta
+++ b/Assets/UI Toolkit/Resources/UI/Panels/ScenarioPropertySection-style.uss.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ed0ae155c3518564f843fa0d2e9b95f8
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0
+  unsupportedSelectorAction: 0

--- a/Assets/UI Toolkit/Resources/UI/Panels/ScenarioPropertySection.uxml
+++ b/Assets/UI Toolkit/Resources/UI/Panels/ScenarioPropertySection.uxml
@@ -1,0 +1,19 @@
+<ui:UXML
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ui="UnityEngine.UIElements"
+    xmlns:nl3d="Netherlands3D.UI.Components"
+    noNamespaceSchemaLocation="../../../../UIElementsSchema/UIElements.xsd"
+    editor-extension-mode="False"
+    name="ScenarioPropertySection"
+    class="scenario-property-section"
+>
+    <nl3d:ContentContainer leading-icon="Scenario" text="Scenario instellingen">
+        <nl3d:CheckboxToggle name="ScenarioToggle" LabelText="Deze map gebruiken als scenario"/>
+
+        <ui:VisualElement class="scenario-property-section__explanation">
+            <ui:Label class="text-base" text="Een scenario is een map waarvan de lagen samen kunnen worden getoond. In de scenariobalk kan steeds één scenario actief zijn; alleen de lagen binnen dat scenario worden weergegeven. Schakel deze optie uit om er weer een gewone map van te maken."/>
+
+            <ui:Label class="text-base scenario-property-section__tip" enable-rich-text="true" text="&lt;b&gt;Tip:&lt;/b&gt; je kunt een gewone map ook omzetten door de naam te beginnen met ‘Scenario:’. Het voorvoegsel wordt daarna automatisch verwijderd."/>
+        </ui:VisualElement>
+    </nl3d:ContentContainer>
+</ui:UXML>

--- a/Assets/UI Toolkit/Resources/UI/Panels/ScenarioPropertySection.uxml.meta
+++ b/Assets/UI Toolkit/Resources/UI/Panels/ScenarioPropertySection.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 2f29bcb6df7433840880a4e5ca4e66ef
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/UI Toolkit/Resources/UI/_Theme.uss
+++ b/Assets/UI Toolkit/Resources/UI/_Theme.uss
@@ -163,6 +163,7 @@
     --icon-scalev1: url("project://database/Assets/Sprites/UI/Icons/Type=ScaleV1,%20Color=white,%20Size=medium.png");
     --icon-scalev2: url("project://database/Assets/Sprites/UI/Icons/Type=ScaleV2,%20Color=white,%20Size=medium.png");
     --icon-scatterobject: url("project://database/Assets/Sprites/UI/Icons/Type=ScatterObject,%20Color=white,%20Size=medium.png");
+    --icon-scenario: url("project://database/Assets/Sprites/UI/Icons/Type=Scenario,%20Color=white,%20Size=medium.png");
     --icon-search: url("project://database/Assets/Sprites/UI/Icons/Type=Search,%20Color=white,%20Size=medium.png");
     --icon-section: url("project://database/Assets/Sprites/UI/Icons/Type=Section,%20Color=white,%20Size=medium.png");
     --icon-selectionbox: url("project://database/Assets/Sprites/UI/Icons/Type=SelectionBox,%20Color=white,%20Size=medium.png");

--- a/Assets/UI Toolkit/Scripts/Components/LayerTreeViewItem.cs
+++ b/Assets/UI Toolkit/Scripts/Components/LayerTreeViewItem.cs
@@ -293,6 +293,7 @@ namespace Netherlands3D.UI.Components
 
         private void OnPropertiesChanged(LayerPropertyData propertyData)
         {
+            UpdateLayerTypeIcon();
             LoadProperties(LayerData.LayerProperties);
         }
 
@@ -362,9 +363,9 @@ namespace Netherlands3D.UI.Components
             layerTypeIcon.Image = LayerTypeSpriteLibrary.GetIconImage(LayerData); //todo test if the icon updates when setting prefab (scatter)
         }
 
-        private void UpdateNameLabels(LayerData layerData, string newName)
+        private void UpdateNameLabels(LayerData layerData, string _)
         {
-            nameInputField.SetValueWithoutNotify(newName);
+            nameInputField.SetValueWithoutNotify(layerData.Name);
         }
 
         public bool HasPropertiesWithPanel(List<LayerPropertyData> properties)

--- a/Assets/UI Toolkit/Scripts/IconImage.cs
+++ b/Assets/UI Toolkit/Scripts/IconImage.cs
@@ -76,6 +76,7 @@
         public const string SCALE_V_1 = "ScaleV1";
         public const string SCALE_V_2 = "ScaleV2";
         public const string SCATTER_OBJECT = "ScatterObject";
+        public const string SCENARIO = "Scenario";
         public const string SEARCH = "Search";
         public const string SECTION = "Section";
         public const string SELECTION_BOX = "SelectionBox";

--- a/Assets/UI Toolkit/Scripts/Panels/LayerPanel.cs
+++ b/Assets/UI Toolkit/Scripts/Panels/LayerPanel.cs
@@ -37,6 +37,7 @@ namespace Netherlands3D.UI.Panels
         private LayerTreeViewItem referenceLayerItem;
         private Button hoveredButton;
 
+        private Button scenarioButton;
         private Button folderButton;
         private Button deleteButton;
         
@@ -78,6 +79,9 @@ namespace Netherlands3D.UI.Panels
             PopulateLayerPanel(ProjectData.Current.RootLayer);
 
             //bottom buttons
+            scenarioButton = this.Q<Button>("ScenarioButton");
+            scenarioButton.RegisterCallback<ClickEvent>(OnScenarioButtonClicked);
+
             folderButton = this.Q<Button>("FolderButton");
             folderButton.RegisterCallback<ClickEvent>(OnFolderButtonClicked);
 
@@ -129,6 +133,7 @@ namespace Netherlands3D.UI.Panels
         {
             App.Layers.LayerAdded.RemoveListener(OnLayerHierarchyChanged);
             App.Layers.LayerRemoved.RemoveListener(OnLayerHierarchyChanged);
+            ProjectData.Current.OnDataChanged.RemoveListener(OnProjectChanged);
         }
 
         public override void OnInspectorClick(InspectorPanel inspector)
@@ -141,7 +146,7 @@ namespace Netherlands3D.UI.Panels
 
             var inInspectorPanel = inspector.worldBound.Contains(panelPos);
             var inTreeViewLayerContainer = scrollView.contentContainer.worldBound.Contains(panelPos);
-            var overButton = deleteButton.worldBound.Contains(panelPos) || folderButton.worldBound.Contains(panelPos);
+            var overButton = deleteButton.worldBound.Contains(panelPos) || folderButton.worldBound.Contains(panelPos) || scenarioButton.worldBound.Contains(panelPos);
             if (inInspectorPanel && !inTreeViewLayerContainer && !overButton)
             {
                 treeView.ClearSelection();
@@ -191,6 +196,57 @@ namespace Netherlands3D.UI.Panels
             doRefresh = true;
         }
 
+        private void OnScenarioButtonClicked(ClickEvent evt)
+        {
+            CreateScenarioAndGroupLayers(treeView.selectedIndices.Count() > 1); //only group if we have multiple layers selected
+        }
+
+        private void CreateScenarioAndGroupLayers(bool group)
+        {
+            var layersToGroup = treeView.selectedItems.Cast<LayerData>().ToList();
+            layersToGroup = layersToGroup.OrderBy(layer => layer.RootId).ToList();
+
+            var newScenario = App.Layers.Add(new ScenarioPreset.Args(GetUniqueScenarioName()));
+
+            var referenceLayer = referenceLayerItem?.LayerData;
+            var siblingIndex = referenceLayer == null ? -1 : referenceLayer.SiblingIndex;
+
+            newScenario.LayerData.SetParent(referenceLayer?.ParentLayer, siblingIndex);
+
+            if (group)
+            {
+                foreach (var selectedLayer in layersToGroup)
+                    selectedLayer.SetParent(newScenario.LayerData);
+            }
+
+            newScenario.LayerData.IsExpanded = true;
+
+            RebuildTree();
+
+            RequestSelection(
+                group ? layersToGroup : new List<LayerData> { newScenario.LayerData });
+        }
+
+        private string GetUniqueScenarioName()
+        {
+            const string defaultName = "Nieuw scenario";
+
+            var existingNames = ProjectData.Current.RootLayer
+                .GetFlatHierarchy()
+                .Select(layer => layer.Name)
+                .ToHashSet();
+
+            if (!existingNames.Contains(defaultName))
+                return defaultName;
+
+            var suffix = 2;
+
+            while (existingNames.Contains($"{defaultName} {suffix}"))
+                suffix++;
+
+            return $"{defaultName} {suffix}";
+        }
+
         private void OnFolderButtonClicked(ClickEvent evt)
         {
             CreateFolderAndGroupLayers(treeView.selectedIndices.Count() > 1); //only group if we have multiple layers selected
@@ -199,7 +255,7 @@ namespace Netherlands3D.UI.Panels
         private void CreateFolderAndGroupLayers(bool group)
         {
             var layersToGroup = treeView.selectedItems.Cast<LayerData>().ToList(); //make a copy with ToList because creating a new folder layer will cause this new layer to be selected and therefore the other layers to be deselected.
-            layersToGroup.OrderBy(l => l.RootId);
+            layersToGroup = layersToGroup.OrderBy(layer => layer.RootId).ToList();
 
             var newGroup = App.Layers.Add(new FolderPreset.Args("Folder"));
             var referenceLayer = referenceLayerItem?.LayerData;
@@ -524,6 +580,10 @@ namespace Netherlands3D.UI.Panels
                     DeleteSelectedLayers();
                 else if (hoveredButton == folderButton)
                     CreateFolderAndGroupLayers(true); //always group when dragging on the button
+                else if (hoveredButton == scenarioButton)
+                {
+                    CreateScenarioAndGroupLayers(true); //always group when dragging on the button
+                }
             }
             else if (hoveredItem != null)
             {

--- a/Assets/UI Toolkit/Scripts/Panels/ScenarioPropertySection.cs
+++ b/Assets/UI Toolkit/Scripts/Panels/ScenarioPropertySection.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using Netherlands3D.Services;
+using Netherlands3D.Twin.Layers.ExtensionMethods;
+using Netherlands3D.Twin.Layers.Properties;
+using Netherlands3D.Twin.Layers.UI.HierarchyInspector;
+using Netherlands3D.UI.Components;
+using Netherlands3D.UI.ExtensionMethods;
+using UnityEngine.UIElements;
+
+namespace Netherlands3D.UI.Panels
+{
+    [UxmlElement]
+    [PropertySection(typeof(IScenarioConvertiblePropertyData), PropertySectionCategory.Settings)]
+    public partial class ScenarioPropertySection : VisualElement, IVisualizationWithPropertyData
+    {
+        private readonly CheckboxToggle scenarioToggle;
+
+        public ScenarioPropertySection()
+        {
+            this.CloneComponentTree("Panels");
+            this.AddComponentStylesheet("Panels");
+
+            scenarioToggle = this.Q<CheckboxToggle>("ScenarioToggle");
+            scenarioToggle.RegisterValueChangedCallback(OnScenarioToggleChanged);
+        }
+
+        public void LoadProperties(List<LayerPropertyData> properties)
+        {
+            var isScenario = properties.Get<ScenarioPropertyData>() != null;
+            scenarioToggle.SetValueWithoutNotify(isScenario);
+        }
+
+        private void OnScenarioToggleChanged(ChangeEvent<bool> evt)
+        {
+            var propertyPanelBehaviour = ServiceLocator.GetService<PropertyPanelBehaviour>();
+            var layer = propertyPanelBehaviour.activeLayer;
+
+            if (layer == null)
+                return;
+
+            ScenarioManager.SetScenarioState(layer, evt.newValue);
+        }
+    }
+}

--- a/Assets/UI Toolkit/Scripts/Panels/ScenarioPropertySection.cs.meta
+++ b/Assets/UI Toolkit/Scripts/Panels/ScenarioPropertySection.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 313940ace66f64642ab963d88cb1f129

--- a/Assets/_Application/Layers/LayerPresets/FolderPropertyData.cs
+++ b/Assets/_Application/Layers/LayerPresets/FolderPropertyData.cs
@@ -3,7 +3,7 @@ using System.Runtime.Serialization;
 namespace Netherlands3D.Twin.Layers.Properties
 {
     [DataContract(Namespace = "https://netherlands3d.eu/schemas/projects/layers/properties", Name = "Folder")]
-    public class FolderPropertyData : LayerPropertyData
+    public class FolderPropertyData : LayerPropertyData, IScenarioConvertiblePropertyData
     {
 
     }

--- a/Assets/_Application/Layers/LayerTypes/LayerTypeSpriteLibrary.cs
+++ b/Assets/_Application/Layers/LayerTypes/LayerTypeSpriteLibrary.cs
@@ -22,7 +22,10 @@ namespace Netherlands3D.Twin.Layers.LayerTypes
 
         public static string GetIconImage(LayerData layer)
         {
-            if (layer.HasProperty<FolderPropertyData>() || layer.HasProperty<ScenarioPropertyData>())
+            if (layer.HasProperty<ScenarioPropertyData>())
+                return IconImage.SCENARIO;
+
+            if (layer.HasProperty<FolderPropertyData>())
                 return IconImage.FOLDER;
 
             if (layer.HasProperty<PolygonSelectionLayerPropertyData>()) // special cases for polygon layers that have a defined shape type

--- a/Assets/_Application/Layers/Properties/IScenarioConvertiblePropertyData.cs
+++ b/Assets/_Application/Layers/Properties/IScenarioConvertiblePropertyData.cs
@@ -1,0 +1,6 @@
+namespace Netherlands3D.Twin.Layers.Properties
+{
+    public interface IScenarioConvertiblePropertyData
+    {
+    }
+}

--- a/Assets/_Application/Layers/Properties/IScenarioConvertiblePropertyData.cs.meta
+++ b/Assets/_Application/Layers/Properties/IScenarioConvertiblePropertyData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9b8b101453a162b4799770d7c27dcef6

--- a/Assets/_Application/Layers/UI/HierarchyInspector/ScenarioManager.cs
+++ b/Assets/_Application/Layers/UI/HierarchyInspector/ScenarioManager.cs
@@ -62,6 +62,8 @@ namespace Netherlands3D.Twin.Layers.UI.HierarchyInspector
         private void OnLayerAdded(LayerData layer)
         {
             SubscribeToLayer(layer);
+            if (layer.HasProperty<ScenarioPropertyData>())
+                selectedScenario = layer;
             RebuildScenarios();
         }
         
@@ -81,10 +83,39 @@ namespace Netherlands3D.Twin.Layers.UI.HierarchyInspector
             RebuildScenarios();
         }
 
-        private void OnLayerNameChanged(LayerData layer, string _)
+        private void OnLayerNameChanged(LayerData layer, string name)
         {
-            UpdateScenarioProperty(layer);
+            if (!layer.HasProperty<FolderPropertyData>() || !TryGetScenarioName(name, out var scenarioName))
+            {
+                RebuildScenarios();
+                return;
+            }
+
+            layer.Name = scenarioName;
+            selectedScenario = layer;
+            SetScenarioState(layer, true);
+        }
+
+        private void OnLayerPropertyChanged(LayerPropertyData _)
+        {
             RebuildScenarios();
+        }
+
+        private static bool TryGetScenarioName(string name, out string scenarioName)
+        {
+            scenarioName = null;
+
+            if (string.IsNullOrWhiteSpace(name) || !name.StartsWith(ScenarioPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            scenarioName = name.Substring(ScenarioPrefix.Length).Trim();
+
+            if (string.IsNullOrWhiteSpace(scenarioName))
+                scenarioName = "Nieuw scenario";
+
+            return true;
         }
 
         private void RebuildScenarios()
@@ -96,9 +127,6 @@ namespace Netherlands3D.Twin.Layers.UI.HierarchyInspector
                 .GetFlatHierarchy();
 
             RefreshLayerSubscriptions(layers);
-
-            foreach (var layer in layers)
-                UpdateScenarioProperty(layer);
 
             scenarios.Clear();
             scenarios.AddRange(
@@ -181,10 +209,7 @@ namespace Netherlands3D.Twin.Layers.UI.HierarchyInspector
             }
         }
 
-        private static void SetScenarioActive(
-    LayerData scenario,
-    bool active
-)
+        private static void SetScenarioActive(LayerData scenario, bool active)
         {
             scenario.ActiveSelf = active;
 
@@ -209,21 +234,16 @@ namespace Netherlands3D.Twin.Layers.UI.HierarchyInspector
             return index >= 0 ? index : null;
         }
 
-        private static void UpdateScenarioProperty(
-            LayerData layer
-        )
+        public static void SetScenarioState(LayerData layer, bool isScenario)
         {
-            var hasScenarioName =
-                IsScenarioName(layer.Name);
-
-            if (hasScenarioName &&
-                layer.HasProperty<FolderPropertyData>() &&
-                !layer.HasProperty<ScenarioPropertyData>())
+            if (isScenario)
             {
+                if (layer.HasProperty<ScenarioPropertyData>())
+                    return;
+
                 layer.SetProperty(new ScenarioPropertyData());
 
-                var folderProperty =
-                    layer.GetProperty<FolderPropertyData>();
+                var folderProperty = layer.GetProperty<FolderPropertyData>();
 
                 if (folderProperty != null)
                     layer.RemoveProperty(folderProperty);
@@ -231,17 +251,15 @@ namespace Netherlands3D.Twin.Layers.UI.HierarchyInspector
                 return;
             }
 
-            if (!hasScenarioName &&
-                layer.HasProperty<ScenarioPropertyData>())
-            {
-                layer.SetProperty(new FolderPropertyData());
+            if (layer.HasProperty<FolderPropertyData>())
+                return;
 
-                var scenarioProperty =
-                    layer.GetProperty<ScenarioPropertyData>();
+            layer.SetProperty(new FolderPropertyData());
 
-                if (scenarioProperty != null)
-                    layer.RemoveProperty(scenarioProperty);
-            }
+            var scenarioProperty = layer.GetProperty<ScenarioPropertyData>();
+
+            if (scenarioProperty != null)
+                layer.RemoveProperty(scenarioProperty);
         }
 
         private static bool IsScenarioName(string name)
@@ -283,9 +301,9 @@ namespace Netherlands3D.Twin.Layers.UI.HierarchyInspector
             if (!subscribedLayers.Add(layer))
                 return;
 
-            layer.NameChanged.AddListener(
-                OnLayerNameChanged
-            );
+            layer.NameChanged.AddListener(OnLayerNameChanged);
+            layer.PropertySet.AddListener(OnLayerPropertyChanged);
+            layer.PropertyRemoved.AddListener(OnLayerPropertyChanged);
         }
 
         private void UnsubscribeFromLayer(LayerData layer)
@@ -293,18 +311,18 @@ namespace Netherlands3D.Twin.Layers.UI.HierarchyInspector
             if (!subscribedLayers.Remove(layer))
                 return;
 
-            layer.NameChanged.RemoveListener(
-                OnLayerNameChanged
-            );
+            layer.NameChanged.RemoveListener(OnLayerNameChanged);
+            layer.PropertySet.RemoveListener(OnLayerPropertyChanged);
+            layer.PropertyRemoved.RemoveListener(OnLayerPropertyChanged);
         }
 
         private void UnsubscribeFromAllLayers()
         {
             foreach (var layer in subscribedLayers)
             {
-                layer.NameChanged.RemoveListener(
-                    OnLayerNameChanged
-                );
+                layer.NameChanged.RemoveListener(OnLayerNameChanged);
+                layer.PropertySet.RemoveListener(OnLayerPropertyChanged);
+                layer.PropertyRemoved.RemoveListener(OnLayerPropertyChanged);
             }
 
             subscribedLayers.Clear();

--- a/Assets/_Functionalities/Scenarios/Scripts/ScenarioPropertyData.cs
+++ b/Assets/_Functionalities/Scenarios/Scripts/ScenarioPropertyData.cs
@@ -3,7 +3,7 @@ using System.Runtime.Serialization;
 namespace Netherlands3D.Twin.Layers.Properties
 {
     [DataContract(Namespace = "https://netherlands3d.eu/schemas/projects/layers/properties", Name = "Scenario")]
-    public class ScenarioPropertyData : LayerPropertyData
+    public class ScenarioPropertyData : LayerPropertyData, IScenarioConvertiblePropertyData
     {  
 
     }


### PR DESCRIPTION
Compare to feature/scenariotoolbar for overview on files changed. I used that branch as a base to be able to test the new functionality with the ui toolkit version of the scenario feature. Changes are limited to only ScenarioManager.cs from that branch, should not create conflicts.

Users can create a new scenario the same way you can add a folder; with a dedicated button (drag selected layers onto the button to group them into a scenario also works for scenarios). Scenario folders now have their own icon and settings button.

The properties panel allows regular folders to be converted into scenarios and scenarios to be changed back into regular folders. The existing Scenario: naming shortcut still works, but the prefix is removed from the visible folder name after conversion.

Layer names, scenario toolbar buttons, icons, and settings stay in sync when a scenario is created, converted, or renamed. Event listeners are also cleaned up when the related UI is removed.