### PR TITLE
Deleted north specific styling

### DIFF
--- a/Assets/UI Toolkit/Resources/UI/Components/ToolbarNavigation-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/ToolbarNavigation-style.uss
@@ -28,13 +28,3 @@
 .app--functionality-first-person-viewer .toolbar-navigation__button.toolbar-navigation__fpv {
     display: flex;
 }
-
-/* We need a deep hierarchy level because of the specificity in the button component */
-.toolbar-navigation .toolbar-navigation__button.toolbar-navigation__compass .icon {
-    --icon-tint-color: var(--color-blue-700);
-}
-
-/* We need a deep hierarchy level because of the specificity in the button component */
-.toolbar-navigation .toolbar-navigation__button.toolbar-navigation__compass.toolbar-navigation__compass--north .icon {
-    --icon-tint-color: var(--color-white);
-}

--- a/Assets/UI Toolkit/Scripts/Components/ToolbarNavigation.cs
+++ b/Assets/UI Toolkit/Scripts/Components/ToolbarNavigation.cs
@@ -50,6 +50,7 @@ namespace Netherlands3D.UI.Components
         private void OnToggleOrthographicView(ChangeEvent<bool> evt)
         {
             ServiceLocator.GetService<CameraService>().ActiveCamera.GetComponent<FreeCamera>()?.EnableOrtographic(evt.newValue);
+            UpdatePerspectiveIcon();
         }
 
         private void UpdatePerspectiveIcon()

--- a/Assets/UI Toolkit/Scripts/Components/ToolbarNavigation.cs
+++ b/Assets/UI Toolkit/Scripts/Components/ToolbarNavigation.cs
@@ -43,7 +43,8 @@ namespace Netherlands3D.UI.Components
         public void UpdateCompass(float yawInDegrees)
         {
             North.Q<Icon>().style.rotate = new StyleRotate(new Rotate(yawInDegrees));
-            North.EnableInClassList("toolbar-navigation__compass--north", yawInDegrees is > 359.0f or < 1.0f);
+            /*Disabled to keep the north arrow base style at all camera angles.*/
+            // North.EnableInClassList("toolbar-navigation__compass--north", yawInDegrees is > 359.0f or < 1.0f);
         }
 
         private void OnToggleOrthographicView(ChangeEvent<bool> evt)

--- a/Assets/UI Toolkit/Scripts/Components/ToolbarNavigation.cs
+++ b/Assets/UI Toolkit/Scripts/Components/ToolbarNavigation.cs
@@ -42,7 +42,7 @@ namespace Netherlands3D.UI.Components
 
         public void UpdateCompass(float yawInDegrees)
         {
-            North.Q<Icon>().style.rotate = new StyleRotate(new Rotate(yawInDegrees));
+            North.Q<Icon>().style.rotate = new StyleRotate(new Rotate(-yawInDegrees));
             /*Disabled to keep the north arrow base style at all camera angles.*/
             // North.EnableInClassList("toolbar-navigation__compass--north", yawInDegrees is > 359.0f or < 1.0f);
         }

--- a/Assets/UI Toolkit/Scripts/Components/ToolbarNavigation.cs
+++ b/Assets/UI Toolkit/Scripts/Components/ToolbarNavigation.cs
@@ -50,7 +50,6 @@ namespace Netherlands3D.UI.Components
         private void OnToggleOrthographicView(ChangeEvent<bool> evt)
         {
             ServiceLocator.GetService<CameraService>().ActiveCamera.GetComponent<FreeCamera>()?.EnableOrtographic(evt.newValue);
-            UpdatePerspectiveIcon();
         }
 
         private void UpdatePerspectiveIcon()

--- a/Assets/UI Toolkit/Scripts/Components/ToolbarNavigation.cs
+++ b/Assets/UI Toolkit/Scripts/Components/ToolbarNavigation.cs
@@ -43,8 +43,6 @@ namespace Netherlands3D.UI.Components
         public void UpdateCompass(float yawInDegrees)
         {
             North.Q<Icon>().style.rotate = new StyleRotate(new Rotate(-yawInDegrees));
-            /*Disabled to keep the north arrow base style at all camera angles.*/
-            // North.EnableInClassList("toolbar-navigation__compass--north", yawInDegrees is > 359.0f or < 1.0f);
         }
 
         private void OnToggleOrthographicView(ChangeEvent<bool> evt)


### PR DESCRIPTION
The north arrow now uses the same styling as the other navigation buttons. It stays white at every camera angle, while the button border turns blue on hover. Commented out functionality in ToolbarNavigation.cs for reuse at a later time.