### PR TITLE
Fixed poygon positioning bug when loading a project with an inactive layer

### DIFF
--- a/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/GeoJsonLayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/GeoJsonLayerGameObject.cs
@@ -145,7 +145,13 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.GeoJsonLayers
         public override void OnLayerActiveInHierarchyChanged(bool isActive)
         {
             base.OnLayerActiveInHierarchyChanged(isActive);
-            if (isActive && startLoadingDataWhenLayerBecomesActive)
+            if (!LayerData.HasValidCredentials) //in case we activate the layer for the first time, and we have invalid credentials, reset the loading flag and wait for valid credentials
+            {
+                startLoadingDataWhenLayerBecomesActive = false;
+                return; 
+            }
+            
+            if (isActive && startLoadingDataWhenLayerBecomesActive) //in case we activate the layer with valid credentials for the first time, and we are still waiting for a load, parse the data.
             {
                 var auth = credentialHandler.Authorization;
                 var uri =  auth.SanitizeUrl(credentialHandler.Uri);

--- a/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/GeoJsonLayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerTypes/GeoJsonLayers/GeoJsonLayerGameObject.cs
@@ -61,7 +61,8 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.GeoJsonLayers
         private GeoJSONPointLayer pointFeaturesLayer;
         
         private ICredentialHandler credentialHandler;
-
+        private bool startLoadingDataWhenLayerBecomesActive = false;
+        
         public struct PendingFeature
         {
             public Feature Feature;
@@ -117,7 +118,15 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.GeoJsonLayers
             }
             
             LayerData.HasValidCredentials = true;
-            StartLoadingData(uri, auth);
+            
+            if(LayerData.ActiveInHierarchy)
+            {
+                StartLoadingData(uri, auth);
+            }
+            else
+            {
+                startLoadingDataWhenLayerBecomesActive = true;
+            }
         }
 
         protected void StartLoadingData(Uri uri, StoredAuthorization auth)
@@ -130,6 +139,18 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.GeoJsonLayers
             else if (uri.IsRemoteAsset())
             {
                 StartCoroutine(parser.ParseGeoJSONStreamRemote(uri, auth));
+            }
+        }
+
+        public override void OnLayerActiveInHierarchyChanged(bool isActive)
+        {
+            base.OnLayerActiveInHierarchyChanged(isActive);
+            if (isActive && startLoadingDataWhenLayerBecomesActive)
+            {
+                var auth = credentialHandler.Authorization;
+                var uri =  auth.SanitizeUrl(credentialHandler.Uri);
+                StartLoadingData(uri, auth);
+                startLoadingDataWhenLayerBecomesActive = false;
             }
         }
 


### PR DESCRIPTION
GeoJsonFeatures now only start visualising when the layer becomes active. This saves resources as possibly unneeded visualisations are not in memory, and it fixes the issue where polygons spawn in the wrong position due to the layer starting out inactive.