### PR TITLE
Icon toggle fixed

### DIFF
--- a/Assets/UI Toolkit/Scripts/Components/ToolbarNavigation.cs
+++ b/Assets/UI Toolkit/Scripts/Components/ToolbarNavigation.cs
@@ -49,6 +49,7 @@ namespace Netherlands3D.UI.Components
         private void OnToggleOrthographicView(ChangeEvent<bool> evt)
         {
             ServiceLocator.GetService<CameraService>().ActiveCamera.GetComponent<FreeCamera>()?.EnableOrtographic(evt.newValue);
+            UpdatePerspectiveIcon();
         }
 
         private void UpdatePerspectiveIcon()


### PR DESCRIPTION
Update the camera mode icon when the orthographic toggle changes, so it always shows the currently active view mode.