### PR TITLE
Fix/het fpv icoontje slepen werkt niet altijd goed

### DIFF
--- a/Assets/UI Toolkit/Scripts/Behaviours/AppRootBehaviour.cs
+++ b/Assets/UI Toolkit/Scripts/Behaviours/AppRootBehaviour.cs
@@ -78,8 +78,13 @@ namespace Netherlands3D
 
         public bool IsPointerOverUI()
         {
+            return IsPointerOverUI(out _);
+        }
+        
+        public bool IsPointerOverUI(out VisualElement picked)
+        {
             Vector2 panelPosition = GetPanelClickPosition();
-            VisualElement picked = appRoot.panel.Pick(panelPosition);
+            picked = appRoot.panel.Pick(panelPosition);
             return picked != null;
         }
     }

--- a/Assets/UI Toolkit/Scripts/Components/ToolbarNavigation.cs
+++ b/Assets/UI Toolkit/Scripts/Components/ToolbarNavigation.cs
@@ -19,7 +19,8 @@ namespace Netherlands3D.UI.Components
             this.CloneComponentTree("Components");
             this.AddComponentStylesheet("Components");
 
-            FPV.Q<Icon>().AddManipulator(new FirstPersonViewManipulator(0));
+            var fpvIcon = FPV.Q<Icon>();
+            FPV.AddManipulator(new FirstPersonViewManipulator(fpvIcon, 0));
             
             RegisterCallback<AttachToPanelEvent>(OnAttachToPanelEvent);
             North.RegisterCallback<ClickEvent>(OnNorthClick);

--- a/Assets/UI Toolkit/Scripts/Manipulators/DragManipulator.cs
+++ b/Assets/UI Toolkit/Scripts/Manipulators/DragManipulator.cs
@@ -28,7 +28,7 @@ public class DragManipulator : PointerManipulator
 
     protected override void RegisterCallbacksOnTarget()
     {
-        target.RegisterCallback<PointerDownEvent>(OnPointerDown);
+        target.RegisterCallback<PointerDownEvent>(OnPointerDown, TrickleDown.TrickleDown);
         target.RegisterCallback<PointerMoveEvent>(OnPointerMove);
         target.RegisterCallback<PointerUpEvent>(OnPointerUp);
         target.RegisterCallback<PointerLeaveEvent>(OnPointerLeave);
@@ -36,7 +36,7 @@ public class DragManipulator : PointerManipulator
 
     protected override void UnregisterCallbacksFromTarget()
     {
-        target.UnregisterCallback<PointerDownEvent>(OnPointerDown);
+        target.UnregisterCallback<PointerDownEvent>(OnPointerDown, TrickleDown.TrickleDown);
         target.UnregisterCallback<PointerMoveEvent>(OnPointerMove);
         target.UnregisterCallback<PointerUpEvent>(OnPointerUp);
         target.UnregisterCallback<PointerLeaveEvent>(OnPointerLeave);

--- a/Assets/UI Toolkit/Scripts/Manipulators/DragManipulator.cs
+++ b/Assets/UI Toolkit/Scripts/Manipulators/DragManipulator.cs
@@ -4,6 +4,8 @@ using UnityEngine.UIElements;
 
 public class DragManipulator : PointerManipulator
 {
+    private readonly TrickleDown trickleDown;
+    
     private Vector3 start;
     private bool isTracking;
     private bool isDragging;
@@ -18,9 +20,10 @@ public class DragManipulator : PointerManipulator
     
     private Vector2 previousPosition;
     
-    public DragManipulator(float deadzone)
+    public DragManipulator(float deadzone, TrickleDown trickleDown = TrickleDown.NoTrickleDown)
     {
         this.movementDeadzone = deadzone;
+        this.trickleDown = trickleDown;
         pointerId = -1;
         activators.Add(new ManipulatorActivationFilter { button = dragMouseButton });
         isTracking = false;
@@ -28,18 +31,18 @@ public class DragManipulator : PointerManipulator
 
     protected override void RegisterCallbacksOnTarget()
     {
-        target.RegisterCallback<PointerDownEvent>(OnPointerDown, TrickleDown.TrickleDown);
-        target.RegisterCallback<PointerMoveEvent>(OnPointerMove);
-        target.RegisterCallback<PointerUpEvent>(OnPointerUp);
-        target.RegisterCallback<PointerLeaveEvent>(OnPointerLeave);
+        target.RegisterCallback<PointerDownEvent>(OnPointerDown, trickleDown);
+        target.RegisterCallback<PointerMoveEvent>(OnPointerMove, trickleDown);
+        target.RegisterCallback<PointerUpEvent>(OnPointerUp, trickleDown);
+        target.RegisterCallback<PointerLeaveEvent>(OnPointerLeave, trickleDown);
     }
 
     protected override void UnregisterCallbacksFromTarget()
     {
-        target.UnregisterCallback<PointerDownEvent>(OnPointerDown, TrickleDown.TrickleDown);
-        target.UnregisterCallback<PointerMoveEvent>(OnPointerMove);
-        target.UnregisterCallback<PointerUpEvent>(OnPointerUp);
-        target.UnregisterCallback<PointerLeaveEvent>(OnPointerLeave);
+        target.UnregisterCallback<PointerDownEvent>(OnPointerDown, trickleDown);
+        target.UnregisterCallback<PointerMoveEvent>(OnPointerMove, trickleDown);
+        target.UnregisterCallback<PointerUpEvent>(OnPointerUp, trickleDown);
+        target.UnregisterCallback<PointerLeaveEvent>(OnPointerLeave, trickleDown);
     }
 
     private void OnPointerDown(PointerDownEvent e)

--- a/Assets/UI Toolkit/Scripts/Manipulators/FirstPersonViewManipulator.cs
+++ b/Assets/UI Toolkit/Scripts/Manipulators/FirstPersonViewManipulator.cs
@@ -20,7 +20,7 @@ public class FirstPersonViewManipulator : DragManipulator
         "Buildings"
     );
 
-    public FirstPersonViewManipulator(VisualElement draggedElement, float deadzone) : base(deadzone)
+    public FirstPersonViewManipulator(VisualElement draggedElement, float deadzone) : base(deadzone, TrickleDown.TrickleDown)
     {
         this.draggedElement = draggedElement;
     }

--- a/Assets/UI Toolkit/Scripts/Manipulators/FirstPersonViewManipulator.cs
+++ b/Assets/UI Toolkit/Scripts/Manipulators/FirstPersonViewManipulator.cs
@@ -4,6 +4,7 @@ using Netherlands3D.Twin;
 using Netherlands3D.Twin.Samplers;
 using UnityEngine;
 using UnityEngine.InputSystem;
+using UnityEngine.UIElements;
 
 public class FirstPersonViewManipulator : DragManipulator
 {
@@ -40,7 +41,10 @@ public class FirstPersonViewManipulator : DragManipulator
         base.OnDragEnded(endPosition);
 
         var mousePos = Mouse.current.position.ReadValue();
-        if (!App.UIRoot.IsPointerOverUI())
+        var picked = App.UIRoot.Root.panel.Pick(App.UIRoot.GetPanelClickPosition());
+        var isPointerOverUI = App.UIRoot.IsPointerOverUI(out picked);
+        isPointerOverUI = isPointerOverUI && picked != target;
+        if (!isPointerOverUI)
         {
             App.UIRoot.EnableFPVUI();
             EnterFPVMode();

--- a/Assets/UI Toolkit/Scripts/Manipulators/FirstPersonViewManipulator.cs
+++ b/Assets/UI Toolkit/Scripts/Manipulators/FirstPersonViewManipulator.cs
@@ -8,8 +8,11 @@ using UnityEngine.UIElements;
 
 public class FirstPersonViewManipulator : DragManipulator
 {
+    private readonly VisualElement draggedElement;
+    
     private Vector2 totalDrag;
     private Vector2 layoutPositionAtDragStart;
+    
 
     private readonly LayerMask layers = LayerMask.GetMask(
         "Default",
@@ -17,8 +20,9 @@ public class FirstPersonViewManipulator : DragManipulator
         "Buildings"
     );
 
-    public FirstPersonViewManipulator(float deadzone) : base(deadzone)
+    public FirstPersonViewManipulator(VisualElement draggedElement, float deadzone) : base(deadzone)
     {
+        this.draggedElement = draggedElement;
     }
 
     protected override void OnDragStarted(Vector2 startPosition)
@@ -32,8 +36,8 @@ public class FirstPersonViewManipulator : DragManipulator
     {
         base.OnDrag(delta);
         totalDrag += delta;
-        target.style.top = layoutPositionAtDragStart.y + totalDrag.y;
-        target.style.left = layoutPositionAtDragStart.x + totalDrag.x;
+        draggedElement.style.top = layoutPositionAtDragStart.y + totalDrag.y;
+        draggedElement.style.left = layoutPositionAtDragStart.x + totalDrag.x;
     }
 
     protected override void OnDragEnded(Vector2 endPosition)
@@ -43,7 +47,7 @@ public class FirstPersonViewManipulator : DragManipulator
         var mousePos = Mouse.current.position.ReadValue();
         var picked = App.UIRoot.Root.panel.Pick(App.UIRoot.GetPanelClickPosition());
         var isPointerOverUI = App.UIRoot.IsPointerOverUI(out picked);
-        isPointerOverUI = isPointerOverUI && picked != target;
+        isPointerOverUI = isPointerOverUI && picked != draggedElement;
         if (!isPointerOverUI)
         {
             App.UIRoot.EnableFPVUI();
@@ -55,8 +59,8 @@ public class FirstPersonViewManipulator : DragManipulator
 
     private void ResetTarget()
     {
-        target.style.top = 0;
-        target.style.left = 0;
+        draggedElement.style.top = 0;
+        draggedElement.style.left = 0;
         totalDrag = Vector2.zero;
     }
 


### PR DESCRIPTION
In `FirstPersonViewManipulator`, in method `OnDragEnded`, isPointerOverUI could return true when hitting the FPV-icon itself.

The mouse position check in `AppRootBehaviour.IsPointerOverUI` is delayed one frame, which causes this to happen often. I did not address this issue.

IsPointerOverUI now returns the VisualElement the mouse cursor is over. I added a check where if this object is the FPV-icon itself, FPV mode is still entered.

I didn't use https://docs.unity3d.com/ScriptReference/UIElements.PickingMode.Ignore.html, because that also ignores pointer events (and I didn't want to toggle it on-and-off repeatedly).