### PR TITLE
Fix/tab doet gekke dingen

### DIFF
--- a/Assets/_Functionalities/FirstPersonViewer/Scripts/FirstPersonViewer.cs
+++ b/Assets/_Functionalities/FirstPersonViewer/Scripts/FirstPersonViewer.cs
@@ -59,8 +59,9 @@ namespace Netherlands3D.FirstPersonViewer
         private void Awake()
         {
             worldTransform = GetComponent<WorldTransform>();
-
+    
             Input.SetExitCallback(ExitViewer);
+            MovementSwitcher.enabled = false;
         }
 
         private void Start()
@@ -124,6 +125,7 @@ namespace Netherlands3D.FirstPersonViewer
         {
             Input.OnFPVEnter();
             MovementSwitcher.ApplyViewer();
+            MovementSwitcher.enabled = true;
         }
 
         private void OnDestroy()
@@ -250,6 +252,7 @@ namespace Netherlands3D.FirstPersonViewer
 
         public void ExitViewer(bool exitOriginalPosition)
         {
+            MovementSwitcher.enabled = false;
             SetMovementVisual(null);
             OnViewerExited.Invoke(exitOriginalPosition);
 


### PR DESCRIPTION
This was caused by the MovementModusSwitcher always being active. Input is handled by pulling every frame.

Now, when not in FPV mode, the movementModusSwitcher component is disabled so that the Update loop doesn't run.