### PR TITLE
Transformpanel fields fix

### DIFF
--- a/Assets/UI Toolkit/Resources/UI/Components/MapViewport-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/MapViewport-style.uss
@@ -19,10 +19,10 @@
 .map-viewport--fixed-size{
     aspect-ratio: 1.6;
     /* grenzen: voorkomt te klein/te groot */
-    min-width: 410px;
-    max-width: 410px; /* TODO: test on different screensizes if this is to big */
-    min-height: 256px;
-    max-height: 256px; /* TODO: test on different screensizes if this is to big */
+    min-width: var(--inspector-width);
+    max-width: var(--inspector-width); /* TODO: test on different screensizes if this is to big */
+    min-height: 260px;
+    max-height: 260px; /* TODO: test on different screensizes if this is to big */
 }
 
 .map-viewport__pin

--- a/Assets/UI Toolkit/Resources/UI/Panels/InspectorPanel-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/InspectorPanel-style.uss
@@ -1,7 +1,6 @@
 .inspector {
     --inspector-bg-color: var(--color-white);
     --inspector-border-radius: var(--spacing-2);
-    --inspector-width: 400px;
     --inspector-section-spacing: var(--spacing-3);
     --inspector-section-header-margin-top: var(--spacing-2);
     --inspector-section-header-spacing: var(--spacing-1);

--- a/Assets/UI Toolkit/Resources/UI/Panels/PropertiesPanel-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/PropertiesPanel-style.uss
@@ -1,9 +1,9 @@
 .properties-panel {
     --properties-bg-color: var(--color-white);
     --properties-border-radius: var(--spacing-2);
-    --properties-width: 400px;
-    --properties-min-width: 320px;
-    --properties-max-width: 520px;
+    --properties-width: var(--inspector-width);
+    --properties-min-width: var(--inspector-min-width);
+    --properties-max-width: var(--inspector-max-width);
 
     min-width: var(--properties-min-width);
     width: var(--properties-width);

--- a/Assets/UI Toolkit/Resources/UI/Panels/SecondaryPropertiesPanel-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/SecondaryPropertiesPanel-style.uss
@@ -1,14 +1,17 @@
 .properties-panel {
     --properties-bg-color: var(--color-white);
     --properties-border-radius: var(--spacing-2);
-    --properties-width: 400px;
+    --properties-width: var(--inspector-width);
+    --properties-min-width: var(--inspector-min-width);
+    --properties-max-width: var(--inspector-max-width);
+
     justify-content: space-between;
     flex-shrink: 0;
     flex-grow: 0;
     align-self: stretch;
-    min-width: 320px;
+    min-width: var(--properties-min-width);
     width: var(--properties-width);
-    max-width: 520px;
+    max-width: var(--properties-max-width);
     margin-left: 0px;
     margin-top: 0px;
     margin-right: 0px;

--- a/Assets/UI Toolkit/Resources/UI/Panels/TransformPropertySection-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/TransformPropertySection-style.uss
@@ -11,3 +11,46 @@
 .transform-property-section__item.transform-property-section__item-last{
     margin-right: 0;
 }
+
+.transform-property-section__axis-header {
+    flex-direction: row;
+    align-items: center;
+    padding-bottom: var(--spacing-1);
+}
+
+.transform-property-section__axis-header-spacer {
+    width: var(--spacing-6);
+    min-width: var(--spacing-6);
+    margin-right: var(--spacing-2);
+}
+
+.transform-property-section__axis-labels {
+    flex-direction: row;
+    flex-grow: 1;
+    min-width: 0;
+}
+
+.transform-property-section__axis-label {
+    flex-grow: 1;
+    margin-right: var(--spacing-2);
+    -unity-text-align: middle-center;
+}
+
+.transform-property-section__axis-label.transform-property-section__axis-label-last {
+    margin-right: 0;
+}
+
+.transform-property-section__row .xyz-field {
+    flex-grow: 1;
+    min-width: 0;
+}
+
+.transform-property-section__row .xyz-field .number-field {
+    flex-grow: 1;
+    min-width: 0;
+}
+
+.transform-property-section__row .xyz-field .number-field__input {
+    flex-grow: 1;
+    min-width: 0;
+}

--- a/Assets/UI Toolkit/Resources/UI/Panels/TransformPropertySection.uxml
+++ b/Assets/UI Toolkit/Resources/UI/Panels/TransformPropertySection.uxml
@@ -1,16 +1,24 @@
 <ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:nl3d="Netherlands3D.UI.Components" noNamespaceSchemaLocation="../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False" name="TransformPropertySection">
     <nl3d:ContentContainer leading-icon="ScaleV1" text="Transformatie">
+        <ui:VisualElement class="transform-property-section__axis-header">
+            <ui:VisualElement class="transform-property-section__axis-header-spacer"/>
+            <ui:VisualElement class="transform-property-section__axis-labels">
+                <ui:Label text="X" class="transform-property-section__axis-label text-header"/>
+                <ui:Label text="Y" class="transform-property-section__axis-label text-header"/>
+                <ui:Label text="Z" class="transform-property-section__axis-label transform-property-section__axis-label-last text-header"/>
+            </ui:VisualElement>
+        </ui:VisualElement>
         <ui:VisualElement class="transform-property-section__row">
             <nl3d:Icon image="Move" class="transform-property-section__item"/>
-            <nl3d:XYZField name="Position" number-field-style="Small" decimal-count="2" class="transform-property-section__item transform-property-section__item-last"/>
+            <nl3d:XYZField name="Position" labels-visible="false" number-field-style="Small" decimal-count="2" class="transform-property-section__item transform-property-section__item-last"/>
         </ui:VisualElement>
         <ui:VisualElement class="transform-property-section__row">
             <nl3d:Icon image="RotateV2" class="transform-property-section__item"/>
-            <nl3d:XYZField name="Rotation" number-field-style="Small" decimal-count="2" class="transform-property-section__item transform-property-section__item-last"/>
+            <nl3d:XYZField name="Rotation" labels-visible="false" number-field-style="Small" decimal-count="2" class="transform-property-section__item transform-property-section__item-last"/>
         </ui:VisualElement>
         <ui:VisualElement class="transform-property-section__row">
             <nl3d:Icon image="ScaleV2" class="transform-property-section__item"/>
-            <nl3d:XYZField name="Scale" number-field-style="Small" decimal-count="2" class="transform-property-section__item transform-property-section__item-last"/>
+            <nl3d:XYZField name="Scale" labels-visible="false" number-field-style="Small" decimal-count="2" class="transform-property-section__item transform-property-section__item-last"/>
         </ui:VisualElement>
     </nl3d:ContentContainer>
 </ui:UXML>

--- a/Assets/UI Toolkit/Resources/UI/_Theme.uss
+++ b/Assets/UI Toolkit/Resources/UI/_Theme.uss
@@ -202,6 +202,6 @@
 
     --inspector-border-radius: var(--spacing-2);
     --inspector-min-width: 320px;
-    --inspector-width: 400px;
+    --inspector-width: 420px;
     --inspector-max-width: 520px;
 }


### PR DESCRIPTION
Resized the inspector panel, properties panel, and minimap for consistent alignment. Reorganized the transform panel by removing individual field labels and adding an X, Y, and Z header row.