### PR TITLE
Fixed possibility of multiple property toggles being active at the same time

### DIFF
--- a/Assets/UI Toolkit/Scripts/Components/LayerTreeViewItem.cs
+++ b/Assets/UI Toolkit/Scripts/Components/LayerTreeViewItem.cs
@@ -229,7 +229,8 @@ namespace Netherlands3D.UI.Components
             
             userData = layerData;
             
-            //update the toggle if the propertysection was already active
+            //Virtualisation causes this LayerTreeViewItem to be reused in some cases, so we disable the property toggle in case it was active, and then re-enable it if the propertyPanelBehaviour's active layer matches this element's layer
+            propertyToggle.SetValueWithoutNotify(false);
             CheckPropertyToggle(propertyPanelBehaviour.activeLayer);
 
             SetAppearance(layerData);


### PR DESCRIPTION
When binding a LayerTreeViewItem, the property toggle state is now set to off (default) and only if the property section is open it is reactivated. Since the LayerTreeViewItems can be reused, the bug was that a LayerTreeViewItem with the toggle on could be reused for a layer that does not have its property panel open.