### PR TITLE
Fix/UI toolkit marges tussen panels in eigenschappenpaneel

### DIFF
--- a/Assets/UI Toolkit/Scripts/Components/ScrollView.cs
+++ b/Assets/UI Toolkit/Scripts/Components/ScrollView.cs
@@ -15,7 +15,6 @@ namespace Netherlands3D.UI.Components
     public partial class ScrollView : UnityEngine.UIElements.ScrollView
     {
         private float itemGap = 12f;
-        private int _lastGapChildCount = -1;
 
         [UxmlAttribute("mode")]
         public ScrollViewMode Mode
@@ -32,7 +31,7 @@ namespace Netherlands3D.UI.Components
             set
             {
                 itemGap = value;
-                ApplyItemGap(force: true);
+                ApplyItemGap();
             }
         }
 
@@ -76,24 +75,21 @@ namespace Netherlands3D.UI.Components
             RegisterCallback<AttachToPanelEvent>(_ =>
             {
                 HookGapHandlers();
-                ApplyItemGap(force: true);
+                ApplyItemGap();
             });
         }
 
-        private void ApplyItemGap(bool force = false)
+        private void ApplyItemGap()
         {
             var cont = contentContainer;
             if (cont == null) return;
 
             int count = cont.childCount;
-            if (!force && count == _lastGapChildCount) return;
-            _lastGapChildCount = count;
 
-            float gap = itemGap;
             for (int i = 0; i < count; i++)
             {
                 var child = cont.ElementAt(i);
-                child.style.marginTop = (i == 0) ? 0 : gap;
+                child.style.marginTop = (i == 0) ? 0 : itemGap;
             }
         }
 


### PR DESCRIPTION
USS does not support `row-gap`, so spacing between elements in a container visualElement (in this case, the NL3D ScrollView) has to be done in code.

An optimization in this code had been implemented that relied on the logic that the child items in the scrollView should only be considered to have changed (and thus the spacing between the child items need to be recalculated) when the number of child items has changed.

In the situations where this goes wrong, this is not the case. I don't think this optimization saves enough resources to warrant it, so I removed it.