### PR TITLE
fpv input is no longer locked when exiting fpv mode mid-animation

### DIFF
--- a/Assets/_Functionalities/FirstPersonViewer/Scripts/FirstPersonViewerInput.cs
+++ b/Assets/_Functionalities/FirstPersonViewer/Scripts/FirstPersonViewerInput.cs
@@ -76,7 +76,7 @@ namespace Netherlands3D.FirstPersonViewer
         public void OnFPVEnter()
         {
             //Only lock mouse when the locking modus is selected.
-            RemoveInputLockConstrain(this); // always start clean
+            inputLocks.Clear(); // always start clean
             ToggleCursor(lockMouseModus);
         }
 


### PR DESCRIPTION
fpv input is no longer locked when exiting fpv mode mid-animation