### PR TITLE
Fix/UI toolkit reuzenrad scatter

### DIFF
--- a/Assets/UI Toolkit/Resources/UI/Panels/ScatterPropertySection-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Panels/ScatterPropertySection-style.uss
@@ -1,0 +1,20 @@
+.scatter-property-section__error-panel {
+    flex-direction: row;
+    margin-top: var(--spacing-1);
+}
+
+.scatter-property-section__error-message-divider{
+    -unity-text-align: upper-center;
+}
+
+.scatter-property-section__error-message-text.scatter-property-section__error-message-divider{
+    margin-left: var(--spacing-1);
+    margin-right: var(--spacing-1);
+}
+
+.scatter-property-section__error-message-text {
+    color: var(--color-warning);
+    margin-left: 0;
+    padding: 0;
+    flex-shrink: 1;
+}

--- a/Assets/UI Toolkit/Resources/UI/Panels/ScatterPropertySection.uxml
+++ b/Assets/UI Toolkit/Resources/UI/Panels/ScatterPropertySection.uxml
@@ -1,4 +1,9 @@
-<ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:nl3d="Netherlands3D.UI.Components" noNamespaceSchemaLocation="../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False"
+<ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xmlns:ui="UnityEngine.UIElements" 
+         xmlns:nl3d="Netherlands3D.UI.Components"
+         xmlns:nl3dP="Netherlands3D.UI.Panels"
+         noNamespaceSchemaLocation="../../../../UIElementsSchema/UIElements.xsd" 
+         editor-extension-mode="False"
          name="ScatterPropertySection" class="scatter-property-section">
     <nl3d:ContentContainer leading-icon="ScatterObject" text="Object verspreiden">
         <ui:VisualElement name="ToggleScatterSection">
@@ -13,5 +18,10 @@
             <nl3d:SliderRange  name="HoogteVariatie" label="Hoogte variatie (m)" low-value="0" high-value="50" class="scatter-property-section__scatter-control" />
             <nl3d:SliderRange  name="DiameterVariatie" label="Diameter variatie (m)" low-value="0" high-value="50" class="scatter-property-section__scatter-control" />
         </ui:VisualElement>
+            <ui:VisualElement name="CannotScatterErrorPanel" class="scatter-property-section__error-panel">
+                <nl3d:Icon image="Warning" color="Warning"/>
+                <ui:Label text="|" class="scatter-property-section__error-message-text scatter-property-section__error-message-divider"/>
+                <ui:Label text="Dit object heeft meer dan 65535 vertices en kan daarom niet in een gebied verspreid worden." class="scatter-property-section__error-message-text"/>
+            </ui:VisualElement>
     </nl3d:ContentContainer>
 </ui:UXML>

--- a/Assets/UI Toolkit/Scripts/Panels/ScatterPropertySection.cs
+++ b/Assets/UI Toolkit/Scripts/Panels/ScatterPropertySection.cs
@@ -61,9 +61,9 @@ namespace Netherlands3D.UI.Panels
         public void LoadProperties(List<LayerPropertyData> properties)
         {
             convertToScatterPropertyData = properties.Get<ToggleScatterPropertyData>();
-            SetEntireSectionVisible(convertToScatterPropertyData.AllowScatter);
+            SetEntireSectionEnabled(convertToScatterPropertyData.AllowScatter);
 
-            convertToScatterPropertyData.AllowScatterChanged.AddListener(SetEntireSectionVisible);
+            convertToScatterPropertyData.AllowScatterChanged.AddListener(SetEntireSectionEnabled);
             convertToggle.RegisterValueChangedCallback(OnConvertToggleValueChanged);
             convertToggle.SetValueWithoutNotify(convertToScatterPropertyData.IsScattered);
 
@@ -95,9 +95,9 @@ namespace Netherlands3D.UI.Panels
         }
 
 
-        private void SetEntireSectionVisible(bool isVisible)
+        private void SetEntireSectionEnabled(bool isVisible)
         {
-            EnableInClassList(UtilityClassConstants.HIDDEN, !isVisible);
+            SetEnabled(isVisible);
         }
 
         private void SetRotationSliderVisible(bool autoRotate)

--- a/Assets/UI Toolkit/Scripts/Panels/ScatterPropertySection.cs
+++ b/Assets/UI Toolkit/Scripts/Panels/ScatterPropertySection.cs
@@ -33,6 +33,8 @@ namespace Netherlands3D.UI.Panels
         private SliderRange heightSliderRange;
         private SliderRange diameterSliderRange;
 
+        private VisualElement cannotScatterErrorPanel;
+
         private List<FillType> fillTypeIndices = new List<FillType>()
         {
             FillType.Fill, // 0
@@ -56,14 +58,16 @@ namespace Netherlands3D.UI.Panels
             rotationSlider = scatterSettingsSection.Q<Slider>("RotatieRaster");
             heightSliderRange = scatterSettingsSection.Q<SliderRange>("HoogteVariatie");
             diameterSliderRange = scatterSettingsSection.Q<SliderRange>("DiameterVariatie");
+            
+            cannotScatterErrorPanel = this.Q<VisualElement>("CannotScatterErrorPanel");
         }
 
         public void LoadProperties(List<LayerPropertyData> properties)
         {
             convertToScatterPropertyData = properties.Get<ToggleScatterPropertyData>();
-            SetEntireSectionEnabled(convertToScatterPropertyData.AllowScatter);
+            SetScatterToggleActive(convertToScatterPropertyData.AllowScatter);
 
-            convertToScatterPropertyData.AllowScatterChanged.AddListener(SetEntireSectionEnabled);
+            convertToScatterPropertyData.AllowScatterChanged.AddListener(SetScatterToggleActive);
             convertToggle.RegisterValueChangedCallback(OnConvertToggleValueChanged);
             convertToggle.SetValueWithoutNotify(convertToScatterPropertyData.IsScattered);
 
@@ -95,9 +99,10 @@ namespace Netherlands3D.UI.Panels
         }
 
 
-        private void SetEntireSectionEnabled(bool isVisible)
+        private void SetScatterToggleActive(bool active)
         {
-            SetEnabled(isVisible);
+            convertToggle.SetEnabled(active);
+            cannotScatterErrorPanel.EnableInClassList(UtilityClassConstants.HIDDEN, active);
         }
 
         private void SetRotationSliderVisible(bool autoRotate)

--- a/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectLayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectLayerGameObject.cs
@@ -28,6 +28,7 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject
         public bool DebugBoundingBox = false;
 
         private int snappingCullingMask = 0;
+        private bool meshIsScatterable = true;
 
         private BoundingBox CalculateWorldBoundsFromRenderers()
         {
@@ -84,9 +85,14 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject
             UpdatePosition(transformProperty.Position);
             UpdateRotation(transformProperty.EulerRotation);
             UpdateScale(transformProperty.LocalScale);
+            meshIsScatterable = MeshIsWithinMaxScatterVertexCount();
             
             ToggleScatterPropertyData scatterProperty = LayerData.GetProperty<ToggleScatterPropertyData>();
-            if(scatterProperty != null) scatterProperty.AllowScatter = LayerData.ParentLayer.HasProperty<PolygonSelectionLayerPropertyData>();
+            if(scatterProperty != null)
+            {
+                scatterProperty.IsEditable = LayerData.ParentLayer.HasProperty<PolygonSelectionLayerPropertyData>();  //we want to show the panel if the layer is scatterable
+                scatterProperty.AllowScatter = meshIsScatterable;  //we want to show a message why we cannot scatter when the layer is scatterable but the mesh is not
+            }
 
             WorldTransform.RecalculatePositionAndRotation();
             previousCoordinate = WorldTransform.Coordinate;
@@ -193,7 +199,11 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject
                         transform.localScale,
                         scaleUnitCharacter);
             InitProperty<ColorPropertyData>(properties);
-            InitProperty<ToggleScatterPropertyData>(properties, p => p.AllowScatter = true);
+            InitProperty<ToggleScatterPropertyData>(properties, p =>
+            {
+                p.IsEditable = LayerData.ParentLayer.HasProperty<PolygonSelectionLayerPropertyData>(); //we want to show the panel if the layer is scatterable
+                p.AllowScatter = meshIsScatterable; //we want to show a message why we cannot scatter when the layer is scatterable but the mesh is not
+            });
         }
 
         protected override void RegisterEventListeners()
@@ -330,9 +340,10 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject
 
         public override void OnLayerDataParentChanged()
         {
-            var allowScatter = LayerData.ParentLayer.HasProperty<PolygonSelectionLayerPropertyData>();
-            var meshIsScatterable = MeshIsWithinMaxScatterVertexCount();
-            LayerData.LayerProperties.Get<ToggleScatterPropertyData>().AllowScatter = allowScatter && meshIsScatterable;
+            var layerCanScatter = LayerData.ParentLayer.HasProperty<PolygonSelectionLayerPropertyData>();
+            var toggleScatterPropertyData = LayerData.LayerProperties.Get<ToggleScatterPropertyData>();
+            toggleScatterPropertyData.IsEditable = layerCanScatter;  //we want to show the panel if the layer is scatterable
+            toggleScatterPropertyData.AllowScatter = meshIsScatterable; //we want to show a message why we cannot scatter when the layer is scatterable but the mesh is not
 
             var propertyPanelService = ServiceLocator.GetService<PropertyPanelBehaviour>();
             if (propertyPanelService.activeLayer == LayerData) //reload the property section if the settings changed

--- a/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectLayerGameObject.cs
+++ b/Assets/_Application/Layers/LayerTypes/HierarchicalObject/HierarchicalObjectLayerGameObject.cs
@@ -331,7 +331,8 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject
         public override void OnLayerDataParentChanged()
         {
             var allowScatter = LayerData.ParentLayer.HasProperty<PolygonSelectionLayerPropertyData>();
-            LayerData.LayerProperties.Get<ToggleScatterPropertyData>().AllowScatter = allowScatter;
+            var meshIsScatterable = MeshIsWithinMaxScatterVertexCount();
+            LayerData.LayerProperties.Get<ToggleScatterPropertyData>().AllowScatter = allowScatter && meshIsScatterable;
 
             var propertyPanelService = ServiceLocator.GetService<PropertyPanelBehaviour>();
             if (propertyPanelService.activeLayer == LayerData) //reload the property section if the settings changed
@@ -391,7 +392,22 @@ namespace Netherlands3D.Twin.Layers.LayerTypes.HierarchicalObject
             ScatterGenerationSettingsPropertyData scatterGenerationSettings = LayerData.GetProperty<ScatterGenerationSettingsPropertyData>();
             scatterGenerationSettings.IsEditable = true;
             App.Layers.VisualizeAs(LayerData, ObjectScatterLayerGameObject.ScatterBasePrefabID);
-           
+        }
+
+        private bool MeshIsWithinMaxScatterVertexCount()
+        {
+            var meshFilters = transform.GetComponentsInChildren<MeshFilter>();
+            int vertexCount = 0;
+            for (int i = 0; i < meshFilters.Length; i++)
+            {
+                vertexCount += meshFilters[i].sharedMesh.vertexCount;
+                if (vertexCount > 65535)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
objects with a combined vertex count of more than 65535 can no longer be scattered to avoid errors. A message will be displayed for the user why the scatter is not possible.