### PR TITLE
Fix/UI toolkit line eigenschappen toont verkeerde waarde in tekst

### DIFF
--- a/Assets/UI Toolkit/Scripts/Components/Slider.cs
+++ b/Assets/UI Toolkit/Scripts/Components/Slider.cs
@@ -30,7 +30,7 @@ namespace Netherlands3D.UI.Components
             if (string.IsNullOrEmpty(label))
                 label = "Label";
 
-            //showInputField = false;
+            showInputField = false;
             fill = true;
 
             RegisterCallback<AttachToPanelEvent>(_ => BuildSliderRow());

--- a/Assets/UI Toolkit/Scripts/Components/Slider.cs
+++ b/Assets/UI Toolkit/Scripts/Components/Slider.cs
@@ -30,7 +30,7 @@ namespace Netherlands3D.UI.Components
             if (string.IsNullOrEmpty(label))
                 label = "Label";
 
-            showInputField = false;
+            //showInputField = false;
             fill = true;
 
             RegisterCallback<AttachToPanelEvent>(_ => BuildSliderRow());
@@ -86,6 +86,16 @@ namespace Netherlands3D.UI.Components
         }
 
         private NumberField inputField;
+        
+        public override void SetValueWithoutNotify(float newValue)
+        {
+            base.SetValueWithoutNotify(newValue);
+            
+            if (inputField == null)
+                return;
+
+            inputField.SetValueWithoutNotify(value);
+        }
 
         private NumberField CreateInputField()
         {


### PR DESCRIPTION
The base method SetValueWithoutNotify (in `UnityEngine.UIElements.BaseSlider`) was already updating an inputTextField (if it exists), but it's not the same one that `Netherlands3D.UI.Components.Slider` uses.

I implemented the override `SetValueWithoutNotify` in `Slider`. It calls the base method where the sliderrow is updated, and then updates Slider's inputField.

