### PR TITLE
fix/hoovergedrag-bij-urls-is-niet-consistent

### DIFF
--- a/Assets/UI Toolkit/Scripts/Components/ChangePointerStyleElement.cs
+++ b/Assets/UI Toolkit/Scripts/Components/ChangePointerStyleElement.cs
@@ -8,9 +8,6 @@ namespace Netherlands3D.UI.Components
     [UxmlElement]
     public partial class ChangePointerStyleElement : VisualElement
     {
-        [DllImport("__Internal")]
-        private static extern string SetCSSCursor(string cursorName = "auto");
-        
         private PointerStyle.Style styleOnHover = PointerStyle.Style.POINTER;
         
         [UxmlAttribute("pointer-style-hover")]

--- a/Assets/UI Toolkit/Scripts/Components/ChangePointerStyleElement.cs
+++ b/Assets/UI Toolkit/Scripts/Components/ChangePointerStyleElement.cs
@@ -1,6 +1,6 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Netherlands3D.UI.ExtensionMethods;
-using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace Netherlands3D.UI.Components
@@ -10,50 +10,11 @@ namespace Netherlands3D.UI.Components
     {
         [DllImport("__Internal")]
         private static extern string SetCSSCursor(string cursorName = "auto");
-
-        public enum PointerStyle
-        {
-            Auto,
-            Default,
-            None,
-            ContextMenu,
-            Help,
-            Pointer,
-            Progress,
-            Wait,
-            Cell,
-            Crosshair,
-            Text,
-            VerticalText,
-            Alias,
-            Copy,
-            Move,
-            NoDrop,
-            NotAllowed,
-            Grab,
-            Grabbing,
-            AllScroll,
-            ColResize,
-            RowResize,
-            NResize,
-            NeResize,
-            EResize,
-            SeResize,
-            SResize,
-            SwResize,
-            WResize,
-            NwResize,
-            EwResize,
-            NsResize,
-            NeswResize,
-            NwseResize
-        }
         
-        private PointerStyle styleOnHover = PointerStyle.Pointer;
-        public static PointerStyle pointerType = PointerStyle.Auto;
+        private PointerStyle.Style styleOnHover = PointerStyle.Style.POINTER;
         
         [UxmlAttribute("pointer-style-hover")]
-        public PointerStyle StyleOnHover { get => styleOnHover; set => styleOnHover = value; }
+        public PointerStyle.Style StyleOnHover { get => styleOnHover; set => styleOnHover = value; }
         
         public ChangePointerStyleElement()
         {
@@ -65,22 +26,12 @@ namespace Netherlands3D.UI.Components
 
         private void OnPointerOver(PointerOverEvent evt)
         {
-            ChangeCursor(StyleOnHover);
+            PointerStyle.RequestCursorChange(this, styleOnHover);
         }
 
         private void OnPointerOut(PointerOutEvent evt)
         {
-            ChangeCursor(PointerStyle.Auto);
-        }
-        
-        public static void ChangeCursor(PointerStyle type)
-        {
-            pointerType = type;
-            var cursorString = type.ToString().ToKebabCase();
-
-#if !UNITY_EDITOR && UNITY_WEBGL
-            SetCSSCursor(cursorString);
-#endif
+            PointerStyle.CancelCursorChange(this);
         }
     }
 }

--- a/Assets/UI Toolkit/Scripts/Components/HelpButton.cs
+++ b/Assets/UI Toolkit/Scripts/Components/HelpButton.cs
@@ -1,13 +1,11 @@
-﻿using Netherlands3D.UI_Toolkit.Scripts;
-using Netherlands3D.UI;
-using Netherlands3D.UI.ExtensionMethods;
+﻿using Netherlands3D.UI.ExtensionMethods;
 using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace Netherlands3D.UI.Components
 {
     [UxmlElement]
-    public partial class HelpButton : UnityEngine.UIElements.Button
+    public partial class HelpButton : ChangePointerStyleElement
     {
         private Icon Icon => this.Q<Icon>("Icon");
 
@@ -24,23 +22,27 @@ namespace Netherlands3D.UI.Components
         public string HelpUrl
         {
             get => helpUrl;
-            set => helpUrl = value;
+            set
+            {
+                helpUrl = value;
+                StyleOnHover = string.IsNullOrEmpty(helpUrl) ? PointerStyle.Auto : PointerStyle.Pointer;
+            }
         }
 
         public HelpButton()
         {
             this.CloneComponentTree("Components");
             this.AddComponentStylesheet("Components");
-
-            if (string.IsNullOrEmpty(helpUrl))
-                helpUrl = "Link naar documentatie";
-
-            // Click navigates to HelpUrl when provided
-            clicked += () =>
-            {
-                if (!string.IsNullOrEmpty(helpUrl))
-                    Application.OpenURL(helpUrl);
-            };
+            
+            RegisterCallback<ClickEvent>(OnClick);
+            
+            StyleOnHover = PointerStyle.Auto;
+        }
+        
+        private void OnClick(ClickEvent evt)
+        {
+            if (!string.IsNullOrEmpty(helpUrl))
+                Application.OpenURL(helpUrl);
         }
     }
 }

--- a/Assets/UI Toolkit/Scripts/Components/HelpButton.cs
+++ b/Assets/UI Toolkit/Scripts/Components/HelpButton.cs
@@ -25,7 +25,7 @@ namespace Netherlands3D.UI.Components
             set
             {
                 helpUrl = value;
-                StyleOnHover = string.IsNullOrEmpty(helpUrl) ? PointerStyle.Auto : PointerStyle.Pointer;
+                StyleOnHover = string.IsNullOrEmpty(helpUrl) ? PointerStyle.Style.AUTO : PointerStyle.Style.POINTER;
             }
         }
 
@@ -35,8 +35,8 @@ namespace Netherlands3D.UI.Components
             this.AddComponentStylesheet("Components");
             
             RegisterCallback<ClickEvent>(OnClick);
-            
-            StyleOnHover = PointerStyle.Auto;
+
+            StyleOnHover = PointerStyle.Style.AUTO;
         }
         
         private void OnClick(ClickEvent evt)


### PR DESCRIPTION
`HelpButton` now extends from ChangePointerStyleElement, which is a custom element that allows us to change to pointer on hover.

When an URL is provider, the cursor changes to a finger (PointerStyle.Pointer). When no URL is provides, the default pointer is used (PointerStyle.Auto). 

I removed changing the url to "Link naar documentatie" when it's empty -- that'll only cause issues.