### PR TITLE
Presentation mode with pinnable UI sections

### DIFF
--- a/Assets/Prefabs/UI/UI v2.prefab
+++ b/Assets/Prefabs/UI/UI v2.prefab
@@ -66,6 +66,7 @@ GameObject:
   - component: {fileID: -2108419079400312055}
   - component: {fileID: 4297113770841784289}
   - component: {fileID: -184948826278789416}
+  - component: {fileID: 2540329924118142087}
   m_Layer: 5
   m_Name: UI v2
   m_TagString: Untagged
@@ -157,7 +158,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d012d4c42b746a49473a2f1d9c8e1a5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: eu.netherlands3d.twin::Netherlands3D.RuntimeTooltips
-  tooltipStyleSheet: {fileID: 7433441132597879392, guid: 733a8d3b7d1a4c679ca7caebd41b26e5, type: 3}
+  tooltipStyleSheet: {fileID: 7433441132597879392, guid: 733a8d3b7d1a4c679ca7caebd41b26e5,
+    type: 3}
 --- !u!114 &5715699707642146679
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -290,6 +292,50 @@ MonoBehaviour:
   m_EditorClassIdentifier: eu.netherlands3d.twin.functionalities::Netherlands3D.Twin.Functionalities.FunctionalityListener
   functionalities:
   - {fileID: 11400000, guid: 77c433a944001411a9376d15fb427d17, type: 2}
+  OnEnableFunctionality:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4429096078737367381}
+        m_TargetAssemblyTypeName: Netherlands3D.AppRootBehaviour, eu.netherlands3d.twin
+        m_MethodName: EnableFunctionality
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  OnDisableFunctionality:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4429096078737367381}
+        m_TargetAssemblyTypeName: Netherlands3D.AppRootBehaviour, eu.netherlands3d.twin
+        m_MethodName: DisableFunctionality
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &2540329924118142087
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 891704482898673965}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc4e15ae4a4b42ffbe4bc9b862a15a6b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: eu.netherlands3d.twin.functionalities::Netherlands3D.Twin.Functionalities.FunctionalityListener
+  functionalities:
+  - {fileID: 11400000, guid: 701372591ba40ef4e9b09a5b5ad8f7d5, type: 2}
   OnEnableFunctionality:
     m_PersistentCalls:
       m_Calls:

--- a/Assets/UI Toolkit/Resources/UI/Components/DefaultHUD-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/DefaultHUD-style.uss
@@ -60,6 +60,7 @@
 .default-hud__bottom-section {
     flex-direction: row;
     align-items: flex-end;
+    flex-shrink: 0;
 }
 
 .default-hud__bottom-info {
@@ -72,4 +73,100 @@
 
 .default-hud__bottom-tools {
     flex-shrink: 0;
+}
+
+.default-hud__top-section > .toolbar-toolbox,
+.default-hud__top-section > .toolbar-scenario {
+    translate: 0 0;
+    transition-property: translate;
+    transition-duration: 0.25s;
+    transition-timing-function: ease-in-out;
+}
+
+.default-hud__left-header {
+    flex-direction: row;
+    align-items: flex-start;
+    flex-shrink: 0;
+}
+
+.presentation-section {
+    translate: 0 0;
+    transition-property: translate;
+    transition-duration: 0.25s;
+    transition-timing-function: ease-in-out;
+}
+
+.presentation-section__pin {
+    display: none;
+}
+
+.presentation-section--active .presentation-section__pin {
+    display: flex;
+}
+
+.default-hud__inspector-zone > .toolbar-main {
+    align-self: flex-start;
+}
+
+.default-hud__navigation-section {
+    position: relative;
+    flex-direction: row;
+    align-items: flex-end;
+    flex-grow: 0;
+    flex-shrink: 0;
+    margin-right: 0;
+
+    transition-property: translate, margin-right;
+    transition-duration: 0.25s, 0.15s;
+    transition-timing-function: ease-in-out;
+    transition-delay: 0.15s, 0s;
+}
+
+.default-hud__navigation-section.presentation-section--hidden {
+    transition-duration: 0.40s, 0.15s;
+    transition-delay: 0s, 0.40s;
+}
+
+.default-hud__minimap-column {
+    flex-direction: column;
+    align-items: flex-end;
+    flex-grow: 0;
+    flex-shrink: 0;
+}
+
+.default-hud__minimap-column > .map-viewport {
+    flex-grow: 0;
+    flex-shrink: 0;
+}
+
+.app--presenting .presentation-section--active .presentation-section__pin,
+.app--presenting .toolbar-toolbox--presentation .toolbar-toolbox__presentation-pin {
+    display: none;
+}
+
+.default-hud__presentation-controls {
+    display: none;
+    flex-direction: column;
+    flex-grow: 0;
+    flex-shrink: 0;
+    align-items: flex-start;
+    margin-right: var(--spacing-2);
+}
+
+.app--functionality-presentation-mode .default-hud__presentation-controls {
+    display: flex;
+}
+
+.app--functionality-presentation-mode .default-hud__presentation-controls > .presentation-section__pin {
+    display: flex;
+}
+
+.app--presenting .default-hud__presentation-controls > .presentation-section__pin {
+    display: none;
+}
+
+.default-hud__presentation-button.toggle {
+    flex: 0 0 auto;
+    height: var(--spacing-11);
+    margin: 0;
 }

--- a/Assets/UI Toolkit/Resources/UI/Components/DefaultHUD-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/DefaultHUD-style.uss
@@ -124,7 +124,7 @@
 
 .default-hud__navigation-section.presentation-section--hidden {
     transition-duration: 0.40s, 0.15s;
-    transition-delay: 0s, 0.40s;
+    transition-delay: 0s, 0s;
 }
 
 .default-hud__minimap-column {

--- a/Assets/UI Toolkit/Resources/UI/Components/DefaultHUD.uxml
+++ b/Assets/UI Toolkit/Resources/UI/Components/DefaultHUD.uxml
@@ -8,12 +8,15 @@
     class="default-hud"
 >
     <ui:VisualElement picking-mode="Ignore" class="default-hud__main-section">
-        <ui:VisualElement picking-mode="Ignore" name="LeftSection" class="default-hud__left-section">
-            <nl3d:HamburgerMenu/>
+        <ui:VisualElement picking-mode="Ignore" name="LeftSection" class="default-hud__left-section presentation-section">
+            <ui:VisualElement picking-mode="Ignore" class="default-hud__left-header">
+                <nl3d:HamburgerMenu class="presentation-section__hover-area" />
+                <nl3d:PinToggle name="LeftPresentationPin" value="true" class="presentation-section__pin presentation-section__hover-area" />
+            </ui:VisualElement>
             <ui:VisualElement picking-mode="Ignore" class="default-hud__inspector-zone">
-                <nl3d:ToolbarMain picking-mode="Ignore"/>
-                <nl3d:InspectorPanel name="Inspector" header-text="Label" toolbar-style="Normal"/>
-                <nl3dP:LegendPanel />
+                <nl3d:ToolbarMain picking-mode="Ignore" class="presentation-section__hover-area" />
+                <nl3d:InspectorPanel name="Inspector" header-text="Label" toolbar-style="Normal" class="presentation-section__hover-area" />
+                <nl3dP:LegendPanel class="presentation-section__hover-area" />
             </ui:VisualElement>
         </ui:VisualElement>
         <ui:VisualElement name="TopSection" class="default-hud__top-section" picking-mode="Ignore">
@@ -27,13 +30,21 @@
     </ui:VisualElement>
     <ui:VisualElement name="BottomSection" picking-mode="Ignore" class="default-hud__bottom-section">
         <ui:VisualElement name="BottomInfo" picking-mode="Ignore" class="default-hud__bottom-info">
-            <nl3d:DebugInfo/>
-            <nl3d:Footer/>
+            <nl3d:DebugInfo />
+            <nl3d:Footer />
         </ui:VisualElement>
-        <ui:VisualElement name="BottomTools" picking-mode="Ignore" class="default-hud__bottom-tools">
-            <nl3d:ToolbarNavigation />
-            <ui:VisualElement name="CameraSlider"/>
+        <ui:VisualElement name="PresentationControls" picking-mode="Ignore" class="default-hud__presentation-controls">
+            <nl3d:PinToggle name="NavigationPresentationPin" value="true" class="presentation-section__pin" />
+            <nl3d:Toggle name="Presentation" class="default-hud__presentation-button" toggle-type="transparent" toggle-style="IconOnly" icon="PresentationChart" tooltip="Presentatiemodus (H)" />
         </ui:VisualElement>
-        <nl3d:MapViewport bottom-left="0, 300000" top-right="280000, 620000" layer-start-index="3" resize-on-hover="true" class="map-viewport--fixed-size"/>
+        <ui:VisualElement name="NavigationSection" picking-mode="Ignore" class="default-hud__navigation-section presentation-section">
+            <ui:VisualElement name="BottomTools" picking-mode="Ignore" class="default-hud__bottom-tools">
+                <nl3d:ToolbarNavigation class="presentation-section__hover-area" />
+                <ui:VisualElement name="CameraSlider" />
+            </ui:VisualElement>
+            <ui:VisualElement name="MinimapColumn" picking-mode="Ignore" class="default-hud__minimap-column">
+                <nl3d:MapViewport bottom-left="0, 300000" top-right="280000, 620000" layer-start-index="3" resize-on-hover="true" class="map-viewport--fixed-size presentation-section__hover-area" />
+            </ui:VisualElement>
+        </ui:VisualElement>
     </ui:VisualElement>
 </ui:UXML>

--- a/Assets/UI Toolkit/Resources/UI/Components/PinToggle-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/PinToggle-style.uss
@@ -1,0 +1,35 @@
+.pin-toggle {
+    flex-grow: 0;
+    flex-shrink: 0;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+
+    width: var(--spacing-8);
+    height: var(--spacing-8);
+    min-width: var(--spacing-8);
+    min-height: var(--spacing-8);
+
+    margin: 0;
+    padding: 0;
+    border-width: 0;
+    background-color: transparent;
+}
+
+.pin-toggle:hover,
+.pin-toggle:active,
+.pin-toggle:checked,
+.pin-toggle:focus {
+    border-width: 0;
+    background-color: transparent;
+}
+
+.pin-toggle > .unity-toggle__input,
+.pin-toggle > .unity-toggle__label {
+    display: none;
+}
+
+.pin-toggle > #Icon {
+    width: var(--spacing-6);
+    height: var(--spacing-6);
+}

--- a/Assets/UI Toolkit/Resources/UI/Components/PinToggle-style.uss.meta
+++ b/Assets/UI Toolkit/Resources/UI/Components/PinToggle-style.uss.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 140ba418f453abe4398ee55e4ee45713
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0
+  unsupportedSelectorAction: 0

--- a/Assets/UI Toolkit/Resources/UI/Components/PinToggle.uxml
+++ b/Assets/UI Toolkit/Resources/UI/Components/PinToggle.uxml
@@ -1,0 +1,10 @@
+<ui:UXML 
+    xmlns:ui="UnityEngine.UIElements" 
+    xmlns:nl3d="Netherlands3D.UI.Components" 
+    editor-extension-mode="False"
+    class="pin-toggle"
+>
+
+    <nl3d:Icon name="Icon" image="Pinned" color="White" picking-mode="Ignore" />
+
+</ui:UXML>

--- a/Assets/UI Toolkit/Resources/UI/Components/PinToggle.uxml.meta
+++ b/Assets/UI Toolkit/Resources/UI/Components/PinToggle.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 3b453e39214273344bb2606037635c57
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/UI Toolkit/Resources/UI/Components/ToolbarToolbox-style.uss
+++ b/Assets/UI Toolkit/Resources/UI/Components/ToolbarToolbox-style.uss
@@ -23,3 +23,16 @@
     flex: 0 auto;
     margin-right: var(--toolbar-toolbox-spacing);
 }
+
+.toolbar-toolbox__presentation-pin {
+    display: none;
+    align-self: flex-start;
+}
+
+.toolbar-toolbox--presentation .toolbar-toolbox__presentation-pin {
+    display: flex;
+}
+
+.toolbar-toolbox--presentation .toolbar-toolbox__group > #Screenshot {
+    margin-right: 0;
+}

--- a/Assets/UI Toolkit/Resources/UI/Components/ToolbarToolbox.uxml
+++ b/Assets/UI Toolkit/Resources/UI/Components/ToolbarToolbox.uxml
@@ -2,5 +2,6 @@
     <ui:VisualElement picking-mode="Ignore" class="toolbar-toolbox__group">
         <nl3d:Toggle name="Dome" toggle-type="transparent" toggle-style="IconOnly" icon="SurfaceDome" tooltip="Kijk onder de grond"/>
         <nl3d:Button name="Screenshot" button-type="transparent" button-style="IconOnly" icon="Camera" tooltip="Neem een screenshot"/>
+        <nl3d:PinToggle name="PresentationPin" value="true" class="toolbar-toolbox__presentation-pin" />
     </ui:VisualElement>
 </ui:UXML>

--- a/Assets/UI Toolkit/Scripts/Behaviours/AppRootBehaviour.cs
+++ b/Assets/UI Toolkit/Scripts/Behaviours/AppRootBehaviour.cs
@@ -1,6 +1,7 @@
 using System;
 using Netherlands3D.Twin;
 using Netherlands3D.Twin.Functionalities;
+using Netherlands3D.Twin.Projects;
 using System.Collections.Generic;
 using Netherlands3D.UI_Toolkit;
 using Netherlands3D.UI.Panels;
@@ -8,6 +9,10 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
 using UnityEngine.UIElements;
+using Netherlands3D.Services;
+using Netherlands3D.Twin.PresentationModus.UIHider;
+using Netherlands3D.UI.Components;
+using Netherlands3D.UI_Toolkit.Scripts.Behaviours;
 
 namespace Netherlands3D
 {
@@ -19,6 +24,19 @@ namespace Netherlands3D
         private UIDocument appDocument;
         private VisualElement appRoot;
 
+        private UIHider presentationUIHider;
+        private Netherlands3D.UI.Components.Toggle presentationToggle;
+        private ProjectData presentationProject;
+
+        private PresentationPanelHider leftPanelHider;
+        private ToolboxPanelHider toolboxPanelHider;
+        private PresentationPanelHider navigationPanelHider;
+        private PinToggle leftPresentationPin;
+        private PinToggle toolboxPresentationPin;
+        private PinToggle navigationPresentationPin;
+
+        private bool hasStarted;
+
         //the excuted order of this script should be executed very early to ensure the presence of the approot. 
         private void Awake()
         {
@@ -29,6 +47,127 @@ namespace Netherlands3D
         private void Start()
         {
             DisableFPVUI();
+
+            hasStarted = true;
+            InitializePresentationSections();
+        }
+
+        private void OnEnable()
+        {
+            if (hasStarted)
+                InitializePresentationSections();
+        }
+
+        private void OnDisable()
+        {
+            DisposePresentationControls();
+
+            toolboxPanelHider?.Dispose();
+            toolboxPanelHider = null;
+
+            navigationPanelHider?.Dispose();
+            navigationPanelHider = null;
+
+            leftPanelHider?.Dispose();
+            leftPanelHider = null;
+        }
+
+        private void InitializePresentationSections()
+        {
+            if (presentationUIHider != null)
+                return;
+
+            var defaultHUD = appRoot.Q<DefaultHUD>();
+            var uiHider = ServiceLocator.GetService<UIHider>();
+
+            InitializePresentationControls(defaultHUD, uiHider);
+
+            var leftSection = defaultHUD.Q<VisualElement>("LeftSection");
+            var navigationSection = defaultHUD.Q<VisualElement>("NavigationSection");
+            var presentationControls = defaultHUD.Q<VisualElement>("PresentationControls");
+            var toolbox = defaultHUD.Q<ToolbarToolbox>();
+            var scenario = defaultHUD.Q<ToolbarScenario>();
+
+            leftPanelHider = new PresentationPanelHider(uiHider, leftSection, leftPresentationPin, UIExitDirection.Left);
+            navigationPanelHider = new PresentationPanelHider(uiHider, navigationSection, navigationPresentationPin, UIExitDirection.Down, releaseHorizontalSpace: true, hoverExclusion: presentationControls);
+            toolboxPanelHider = new ToolboxPanelHider(uiHider, toolbox, scenario);
+        }
+
+        private void InitializePresentationControls(DefaultHUD defaultHUD, UIHider uiHider)
+        {
+            presentationUIHider = uiHider;
+            presentationToggle = defaultHUD.Q<Netherlands3D.UI.Components.Toggle>("Presentation");
+            leftPresentationPin = defaultHUD.Q<PinToggle>("LeftPresentationPin");
+            toolboxPresentationPin = defaultHUD.Q<PinToggle>("PresentationPin");
+            navigationPresentationPin = defaultHUD.Q<PinToggle>("NavigationPresentationPin");
+            presentationProject = ProjectData.Current;
+
+            RestorePresentationPins(presentationProject);
+
+            presentationToggle.RegisterValueChangedCallback(OnPresentationChanged);
+            leftPresentationPin.RegisterValueChangedCallback(OnPresentationPinChanged);
+            toolboxPresentationPin.RegisterValueChangedCallback(OnPresentationPinChanged);
+            navigationPresentationPin.RegisterValueChangedCallback(OnPresentationPinChanged);
+            presentationUIHider.PresentationChanged += UpdatePresentationControls;
+            presentationProject.OnDataChanged.AddListener(OnPresentationProjectChanged);
+
+            UpdatePresentationControls();
+        }
+
+        private void OnPresentationChanged(ChangeEvent<bool> evt)
+        {
+            presentationUIHider.SetPresenting(evt.newValue);
+            UpdatePresentationControls();
+        }
+
+        private void UpdatePresentationControls()
+        {
+            presentationToggle.SetValueWithoutNotify(presentationUIHider.IsPresenting);
+            appRoot.EnableInClassList("app--presenting", presentationUIHider.IsPresenting);
+        }
+
+        private void OnPresentationPinChanged(ChangeEvent<bool> evt)
+        {
+            presentationProject.PresentationLeftPinned = leftPresentationPin.value;
+            presentationProject.PresentationToolboxPinned = toolboxPresentationPin.value;
+            presentationProject.PresentationNavigationPinned = navigationPresentationPin.value;
+        }
+
+        private void RestorePresentationPins(ProjectData project)
+        {
+            leftPresentationPin.SetValueWithoutNotify(project.PresentationLeftPinned);
+            toolboxPresentationPin.SetValueWithoutNotify(project.PresentationToolboxPinned);
+            navigationPresentationPin.SetValueWithoutNotify(project.PresentationNavigationPinned);
+        }
+
+        private void OnPresentationProjectChanged(ProjectData project)
+        {
+            RestorePresentationPins(project);
+
+            if (presentationUIHider.IsPresenting)
+                presentationUIHider.SetPresenting(false);
+            else
+                presentationUIHider.RefreshPanels();
+        }
+
+        private void DisposePresentationControls()
+        {
+            if (presentationUIHider == null)
+                return;
+
+            presentationToggle.UnregisterValueChangedCallback(OnPresentationChanged);
+            leftPresentationPin.UnregisterValueChangedCallback(OnPresentationPinChanged);
+            toolboxPresentationPin.UnregisterValueChangedCallback(OnPresentationPinChanged);
+            navigationPresentationPin.UnregisterValueChangedCallback(OnPresentationPinChanged);
+            presentationUIHider.PresentationChanged -= UpdatePresentationControls;
+            presentationProject.OnDataChanged.RemoveListener(OnPresentationProjectChanged);
+
+            presentationUIHider = null;
+            presentationToggle = null;
+            leftPresentationPin = null;
+            toolboxPresentationPin = null;
+            navigationPresentationPin = null;
+            presentationProject = null;
         }
 
         //todo: in the future we might want to create a list of huds we can switch between, so we avoid multiple true/false permutations, but for now we only have 2, so this is not needed yet
@@ -52,6 +191,9 @@ namespace Netherlands3D
         public void EnableFunctionality(Functionality functionality)
         {
             appRoot.AddToClassList("app--functionality-" + functionality.Id);
+
+            if (functionality.Id == UIHider.FunctionalityId)
+                ServiceLocator.GetService<UIHider>().SetPresentationEnabled(true);
         }
 
         /// <summary>
@@ -61,6 +203,9 @@ namespace Netherlands3D
         public void DisableFunctionality(Functionality functionality)
         {
             appRoot.RemoveFromClassList("app--functionality-" + functionality.Id);
+
+            if (functionality.Id == UIHider.FunctionalityId)
+                ServiceLocator.GetService<UIHider>().SetPresentationEnabled(false);
         }
 
         public Vector2 GetPanelClickPosition()

--- a/Assets/UI Toolkit/Scripts/Behaviours/PresentationPanelHider.cs
+++ b/Assets/UI Toolkit/Scripts/Behaviours/PresentationPanelHider.cs
@@ -23,6 +23,7 @@ namespace Netherlands3D.UI_Toolkit.Scripts.Behaviours
         private readonly UIExitDirection direction;
         private readonly List<VisualElement> hoverAreas;
         private readonly bool releaseHorizontalSpace;
+        private bool horizontalSpaceReleased;
         private readonly VisualElement hoverExclusion;
 
         private bool presentationEnabled;
@@ -48,6 +49,7 @@ namespace Netherlands3D.UI_Toolkit.Scripts.Behaviours
             section.RegisterCallback<AttachToPanelEvent>(OnAttachToPanel);
             section.RegisterCallback<DetachFromPanelEvent>(OnDetachFromPanel);
             section.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            section.RegisterCallback<TransitionEndEvent>(OnTransitionEnd);
             root.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
 
             if (section.panel != null)
@@ -93,6 +95,7 @@ namespace Netherlands3D.UI_Toolkit.Scripts.Behaviours
         public void Show()
         {
             IsHidden = false;
+            horizontalSpaceReleased = false;
             section.RemoveFromClassList(HiddenClassName);
             ApplyPosition();
         }
@@ -123,6 +126,18 @@ namespace Netherlands3D.UI_Toolkit.Scripts.Behaviours
 
         private void OnGeometryChanged(GeometryChangedEvent evt)
         {
+            ApplyPosition();
+        }
+
+        private void OnTransitionEnd(TransitionEndEvent evt)
+        {
+            if (disposed || evt.target != section || !releaseHorizontalSpace || !IsHidden || horizontalSpaceReleased)
+                return;
+
+            if (!evt.stylePropertyNames.Contains("translate"))
+                return;
+
+            horizontalSpaceReleased = true;
             ApplyPosition();
         }
 
@@ -260,7 +275,7 @@ namespace Netherlands3D.UI_Toolkit.Scripts.Behaviours
                 var width = section.layout.width;
 
                 if (!float.IsNaN(width) && width > 0f)
-                    section.style.marginRight = IsHidden ? -width : 0f;
+                    section.style.marginRight = IsHidden && horizontalSpaceReleased ? -width : 0f;
             }
 
             if (!IsHidden)
@@ -312,6 +327,7 @@ namespace Netherlands3D.UI_Toolkit.Scripts.Behaviours
             section.UnregisterCallback<AttachToPanelEvent>(OnAttachToPanel);
             section.UnregisterCallback<DetachFromPanelEvent>(OnDetachFromPanel);
             section.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            section.UnregisterCallback<TransitionEndEvent>(OnTransitionEnd);
             root.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
 
             section.RemoveFromClassList(PresentationClassName);

--- a/Assets/UI Toolkit/Scripts/Behaviours/PresentationPanelHider.cs
+++ b/Assets/UI Toolkit/Scripts/Behaviours/PresentationPanelHider.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Collections.Generic;
+using Netherlands3D.Twin;
+using Netherlands3D.Twin.PresentationModus.UIHider;
+using Netherlands3D.UI.Components;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Netherlands3D.UI_Toolkit.Scripts.Behaviours
+{
+    public sealed class PresentationPanelHider : IPanelHider, IDisposable
+    {
+        private const string PresentationClassName = "presentation-section--active";
+        private const string HiddenClassName = "presentation-section--hidden";
+        private const float RevealDistance = 16f;
+        private const float BottomRevealDistance = 80f;
+        private const float HoverBuffer = 12f;
+
+        private readonly UIHider uiHider;
+        private readonly VisualElement section;
+        private readonly VisualElement root;
+        private readonly PinToggle pin;
+        private readonly UIExitDirection direction;
+        private readonly List<VisualElement> hoverAreas;
+        private readonly bool releaseHorizontalSpace;
+        private readonly VisualElement hoverExclusion;
+
+        private bool presentationEnabled;
+        private bool registered;
+        private bool disposed;
+
+        public bool IsHidden { get; private set; }
+        public bool Pinned => pin.value;
+
+        public PresentationPanelHider(UIHider uiHider, VisualElement section, PinToggle pin, UIExitDirection direction, bool releaseHorizontalSpace = false, VisualElement hoverExclusion = null)
+        {
+            this.uiHider = uiHider;
+            this.section = section;
+            this.pin = pin;
+            this.direction = direction;
+            this.releaseHorizontalSpace = releaseHorizontalSpace;
+            this.hoverExclusion = hoverExclusion;
+
+            root = App.UIRoot.Root;
+            hoverAreas = section.Query<VisualElement>(className: "presentation-section__hover-area").ToList();
+
+            pin.RegisterValueChangedCallback(OnPinChanged);
+            section.RegisterCallback<AttachToPanelEvent>(OnAttachToPanel);
+            section.RegisterCallback<DetachFromPanelEvent>(OnDetachFromPanel);
+            section.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            root.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+
+            if (section.panel != null)
+                Register();
+        }
+
+        private void OnAttachToPanel(AttachToPanelEvent evt)
+        {
+            if (evt.target == section)
+                Register();
+        }
+
+        private void OnDetachFromPanel(DetachFromPanelEvent evt)
+        {
+            if (evt.target == section)
+                Unregister();
+        }
+
+        private void Register()
+        {
+            if (registered || disposed)
+                return;
+
+            registered = true;
+            uiHider.Register(this);
+        }
+
+        private void Unregister()
+        {
+            if (!registered)
+                return;
+
+            registered = false;
+            uiHider.Unregister(this);
+        }
+
+        public void HideUI(bool hideUI)
+        {
+            presentationEnabled = hideUI;
+            section.EnableInClassList(PresentationClassName, hideUI);
+        }
+
+        public void Show()
+        {
+            IsHidden = false;
+            section.RemoveFromClassList(HiddenClassName);
+            ApplyPosition();
+        }
+
+        public void Hide()
+        {
+            if (!presentationEnabled || Pinned)
+            {
+                Show();
+                return;
+            }
+
+            if (IsHidden)
+                return;
+
+            IsHidden = true;
+            section.AddToClassList(HiddenClassName);
+            ApplyPosition();
+        }
+
+        private void OnPinChanged(ChangeEvent<bool> evt)
+        {
+            if (evt.newValue)
+                Show();
+            else
+                Hide();
+        }
+
+        private void OnGeometryChanged(GeometryChangedEvent evt)
+        {
+            ApplyPosition();
+        }
+
+        private bool HasVisibleHierarchy()
+        {
+            if (section.panel == null || section.parent == null || !section.visible)
+                return false;
+
+            for (var element = section; element != null; element = element.parent)
+            {
+                if (element.resolvedStyle.display == DisplayStyle.None)
+                    return false;
+            }
+
+            return true;
+        }
+
+        private Rect GetShownBounds()
+        {
+            return section.parent.LocalToWorld(section.layout);
+        }
+
+        private Rect GetScreenBounds()
+        {
+            var topLeft = App.UIRoot.GetUIPositionFromScreenPosition(new Vector2(0f, Screen.height));
+            var bottomRight = App.UIRoot.GetUIPositionFromScreenPosition(new Vector2(Screen.width, 0f));
+
+            return Rect.MinMaxRect(topLeft.x, topLeft.y, bottomRight.x, bottomRight.y);
+        }
+
+        public bool IsMouseOver(Vector2 mousePos)
+        {
+            if (!HasVisibleHierarchy())
+                return false;
+
+            var position = App.UIRoot.GetUIPositionFromScreenPosition(mousePos);
+            var screenBounds = GetScreenBounds();
+
+            if (!ContainsPosition(screenBounds, position))
+                return false;
+
+            if (hoverExclusion != null && hoverExclusion.panel == section.panel && hoverExclusion.visible && hoverExclusion.resolvedStyle.display != DisplayStyle.None)
+            {
+                var bounds = hoverExclusion.worldBound;
+                bounds.xMin -= HoverBuffer;
+                bounds.xMax += HoverBuffer;
+                bounds.yMin -= HoverBuffer;
+                bounds.yMax += HoverBuffer;
+
+                if (ContainsPosition(bounds, position))
+                    return !IsHidden;
+            }
+
+            if (ContainsPosition(GetRevealBounds(screenBounds), position))
+                return true;
+
+            if (IsHidden)
+                return false;
+
+            for (var i = 0; i < hoverAreas.Count; i++)
+            {
+                var area = hoverAreas[i];
+
+                if (!IsHoverAreaVisible(area))
+                    continue;
+
+                var bounds = area.worldBound;
+
+                bounds.xMin -= HoverBuffer;
+                bounds.xMax += HoverBuffer;
+                bounds.yMin -= HoverBuffer;
+                bounds.yMax += HoverBuffer;
+
+                if (ContainsPosition(bounds, position))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private bool IsHoverAreaVisible(VisualElement area)
+        {
+            if (area.panel != section.panel || !area.visible || !section.Contains(area))
+                return false;
+
+            for (var element = area; element != section; element = element.parent)
+            {
+                if (element.resolvedStyle.display == DisplayStyle.None)
+                    return false;
+            }
+
+            var bounds = area.worldBound;
+            return bounds.width > 0f && bounds.height > 0f;
+        }
+
+        private Rect GetRevealBounds(Rect screenBounds)
+        {
+            var bounds = screenBounds;
+
+            switch (direction)
+            {
+                case UIExitDirection.Left:
+                    bounds.xMax = bounds.xMin + RevealDistance;
+                    break;
+
+                case UIExitDirection.Right:
+                    bounds.xMin = bounds.xMax - RevealDistance;
+                    break;
+
+                case UIExitDirection.Up:
+                    bounds.yMax = bounds.yMin + RevealDistance;
+                    break;
+
+                case UIExitDirection.Down:
+                    bounds.yMin = bounds.yMax - BottomRevealDistance;
+                    break;
+            }
+
+            return bounds;
+        }
+
+        private static bool ContainsPosition(Rect bounds, Vector2 position)
+        {
+            return position.x >= bounds.xMin && position.x <= bounds.xMax &&
+                   position.y >= bounds.yMin && position.y <= bounds.yMax;
+        }
+
+        private void ApplyPosition()
+        {
+            if (section.panel == null || section.parent == null)
+                return;
+
+            if (releaseHorizontalSpace)
+            {
+                var width = section.layout.width;
+
+                if (!float.IsNaN(width) && width > 0f)
+                    section.style.marginRight = IsHidden ? -width : 0f;
+            }
+
+            if (!IsHidden)
+            {
+                section.style.translate = new Translate(0f, 0f);
+                return;
+            }
+
+            if (!HasVisibleHierarchy())
+                return;
+
+            var bounds = GetShownBounds();
+
+            if (float.IsNaN(bounds.width) || float.IsNaN(bounds.height) || bounds.width <= 0f || bounds.height <= 0f)
+                return;
+
+            var screenBounds = GetScreenBounds();
+            var offset = direction switch
+            {
+                UIExitDirection.Left => new Vector2(screenBounds.xMin - bounds.xMax - 1f, 0f),
+                UIExitDirection.Right => new Vector2(screenBounds.xMax - bounds.xMin + 1f, 0f),
+                UIExitDirection.Up => new Vector2(0f, screenBounds.yMin - bounds.yMax - 1f),
+                UIExitDirection.Down => new Vector2(0f, screenBounds.yMax - bounds.yMin + 1f),
+                _ => Vector2.zero
+            };
+
+            var origin = section.parent.WorldToLocal(bounds.position);
+            var destination = section.parent.WorldToLocal(bounds.position + offset);
+            var localOffset = destination - origin;
+
+            section.style.translate = new Translate(localOffset.x, localOffset.y);
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+                return;
+
+            section.RemoveFromClassList(HiddenClassName);
+
+            if (releaseHorizontalSpace)
+                section.style.marginRight = StyleKeyword.Null;
+
+            IsHidden = false;
+            disposed = true;
+            Unregister();
+
+            pin.UnregisterValueChangedCallback(OnPinChanged);
+            section.UnregisterCallback<AttachToPanelEvent>(OnAttachToPanel);
+            section.UnregisterCallback<DetachFromPanelEvent>(OnDetachFromPanel);
+            section.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            root.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+
+            section.RemoveFromClassList(PresentationClassName);
+            section.style.translate = StyleKeyword.Null;
+        }
+    }
+}

--- a/Assets/UI Toolkit/Scripts/Behaviours/PresentationPanelHider.cs.meta
+++ b/Assets/UI Toolkit/Scripts/Behaviours/PresentationPanelHider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 97c3ee5247a908d409507503b7be2b1f

--- a/Assets/UI Toolkit/Scripts/Behaviours/ToolboxPanelHider.cs
+++ b/Assets/UI Toolkit/Scripts/Behaviours/ToolboxPanelHider.cs
@@ -1,0 +1,197 @@
+using System;
+using Netherlands3D.Twin;
+using Netherlands3D.Twin.PresentationModus.UIHider;
+using Netherlands3D.UI.Components;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Netherlands3D.UI_Toolkit.Scripts.Behaviours
+{
+    public sealed class ToolboxPanelHider : IPanelHider, IDisposable
+    {
+        private const string PresentationClassName = "toolbar-toolbox--presentation";
+        private const float RevealDistance = 16f;
+        private const float HoverBuffer = 12f;
+
+        private readonly UIHider uiHider;
+        private readonly ToolbarToolbox toolbox;
+        private readonly ToolbarScenario scenario;
+        private readonly PinToggle pin;
+
+        private bool presentationEnabled;
+        private bool registered;
+        private bool disposed;
+
+        public bool IsHidden { get; private set; }
+        public bool Pinned => pin.value;
+
+        public ToolboxPanelHider(UIHider uiHider, ToolbarToolbox toolbox, ToolbarScenario scenario)
+        {
+            this.uiHider = uiHider;
+            this.toolbox = toolbox;
+            this.scenario = scenario;
+
+            pin = toolbox.Q<PinToggle>("PresentationPin");
+
+            pin.RegisterValueChangedCallback(OnPinChanged);
+            toolbox.RegisterCallback<AttachToPanelEvent>(OnAttachToPanel);
+            toolbox.RegisterCallback<DetachFromPanelEvent>(OnDetachFromPanel);
+            toolbox.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            scenario.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+
+            if (toolbox.panel != null)
+                Register();
+        }
+
+        private void OnAttachToPanel(AttachToPanelEvent evt)
+        {
+            if (evt.target == toolbox)
+                Register();
+        }
+
+        private void OnDetachFromPanel(DetachFromPanelEvent evt)
+        {
+            if (evt.target == toolbox)
+                Unregister();
+        }
+
+        private void Register()
+        {
+            if (registered || disposed)
+                return;
+
+            registered = true;
+            uiHider.Register(this);
+        }
+
+        private void Unregister()
+        {
+            if (!registered)
+                return;
+
+            registered = false;
+            uiHider.Unregister(this);
+        }
+
+        public void HideUI(bool hideUI)
+        {
+            presentationEnabled = hideUI;
+            toolbox.EnableInClassList(PresentationClassName, hideUI);
+        }
+
+        public void Show()
+        {
+            IsHidden = false;
+            ApplyPosition();
+        }
+
+        public void Hide()
+        {
+            IsHidden = presentationEnabled && !Pinned;
+            ApplyPosition();
+        }
+
+        private void OnPinChanged(ChangeEvent<bool> evt)
+        {
+            if (evt.newValue)
+                Show();
+            else
+                Hide();
+        }
+
+        private void OnGeometryChanged(GeometryChangedEvent evt)
+        {
+            ApplyPosition();
+        }
+
+        private bool HasVisibleHierarchy()
+        {
+            if (toolbox.panel == null || !toolbox.visible)
+                return false;
+
+            for (var element = (VisualElement)toolbox; element != null; element = element.parent)
+            {
+                if (element.resolvedStyle.display == DisplayStyle.None)
+                    return false;
+            }
+
+            return true;
+        }
+
+        private Rect GetShownBounds()
+        {
+            var position = toolbox.parent.LocalToWorld(toolbox.layout.position);
+            return new Rect(position, toolbox.layout.size);
+        }
+
+        public bool IsMouseOver(Vector2 mousePos)
+        {
+            if (!HasVisibleHierarchy())
+                return false;
+
+            var position = App.UIRoot.GetUIPositionFromScreenPosition(mousePos);
+            var topLeft = App.UIRoot.GetUIPositionFromScreenPosition(new Vector2(0f, Screen.height));
+            var bottomRight = App.UIRoot.GetUIPositionFromScreenPosition(new Vector2(Screen.width, 0f));
+
+            if (position.x < topLeft.x || position.x > bottomRight.x || position.y < topLeft.y || position.y > bottomRight.y)
+                return false;
+
+            if (position.y <= topLeft.y + RevealDistance)
+                return true;
+
+            if (IsHidden)
+                return false;
+
+            var shownBounds = GetShownBounds();
+            var hoverBounds = Rect.MinMaxRect(shownBounds.xMin - HoverBuffer, topLeft.y, shownBounds.xMax + HoverBuffer, shownBounds.yMax + HoverBuffer);
+
+            return hoverBounds.Contains(position);
+        }
+
+        private void ApplyPosition()
+        {
+            if (toolbox.panel == null || toolbox.parent == null)
+                return;
+
+            if (!IsHidden)
+            {
+                toolbox.style.translate = new Translate(0f, 0f);
+                scenario.style.translate = new Translate(0f, 0f);
+                return;
+            }
+
+            var shownBounds = GetShownBounds();
+
+            if (float.IsNaN(shownBounds.height) || shownBounds.height <= 0f)
+                return;
+
+            var screenTop = App.UIRoot.GetUIPositionFromScreenPosition(new Vector2(0f, Screen.height)).y;
+            toolbox.style.translate = new Translate(0f, screenTop - shownBounds.yMax - 1f);
+
+            if (scenario.resolvedStyle.display == DisplayStyle.None)
+                return;
+
+            var scenarioOffset = toolbox.layout.y - scenario.layout.y;
+            scenario.style.translate = new Translate(0f, scenarioOffset);
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+                return;
+
+            disposed = true;
+            Unregister();
+
+            pin.UnregisterValueChangedCallback(OnPinChanged);
+            toolbox.UnregisterCallback<AttachToPanelEvent>(OnAttachToPanel);
+            toolbox.UnregisterCallback<DetachFromPanelEvent>(OnDetachFromPanel);
+            toolbox.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            scenario.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+
+            toolbox.RemoveFromClassList(PresentationClassName);
+            toolbox.style.translate = StyleKeyword.Null;
+            scenario.style.translate = StyleKeyword.Null;
+        }
+    }
+}

--- a/Assets/UI Toolkit/Scripts/Behaviours/ToolboxPanelHider.cs.meta
+++ b/Assets/UI Toolkit/Scripts/Behaviours/ToolboxPanelHider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 951e909c3ca85f447a2076b2e41bc403

--- a/Assets/UI Toolkit/Scripts/Components/PinToggle.cs
+++ b/Assets/UI Toolkit/Scripts/Components/PinToggle.cs
@@ -1,0 +1,52 @@
+using Netherlands3D.UI.ExtensionMethods;
+using Netherlands3D.UI_Toolkit.Scripts;
+using UnityEngine.UIElements;
+
+namespace Netherlands3D.UI.Components
+{
+    // TODO: Extract a reusable IconToggle with configurable on/off icons when another feature needs it.
+    [UxmlElement]
+    public partial class PinToggle : UnityEngine.UIElements.Toggle
+    {
+        private Icon icon;
+
+        public override bool value
+        {
+            get => base.value;
+            set
+            {
+                base.value = value;
+                UpdateIcon();
+            }
+        }
+
+        public PinToggle()
+        {
+            this.CloneComponentTree("Components");
+            this.AddComponentStylesheet("Components");
+            AddToClassList("pin-toggle");
+
+            icon = this.Q<Icon>("Icon");
+            UpdateIcon();
+        }
+
+        public override void SetValueWithoutNotify(bool newValue)
+        {
+            base.SetValueWithoutNotify(newValue);
+            UpdateIcon();
+        }
+
+        private void UpdateIcon()
+        {
+            if (icon == null)
+                return;
+
+            var image = value ? IconImage.PINNED : IconImage.UNPINNED;
+
+            if (icon.Image != image)
+                icon.Image = image;
+
+            tooltip = value ? "Sectie losmaken" : "Sectie vastzetten";
+        }
+    }
+}

--- a/Assets/UI Toolkit/Scripts/Components/PinToggle.cs.meta
+++ b/Assets/UI Toolkit/Scripts/Components/PinToggle.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0dc91dbf20047364ab23d9e09a6f0d05

--- a/Assets/UI Toolkit/Scripts/Panels/SettingsPanel.cs
+++ b/Assets/UI Toolkit/Scripts/Panels/SettingsPanel.cs
@@ -50,12 +50,12 @@ namespace Netherlands3D.UI.Panels
                 this.Q<ScrollView>().Add(fpvSection);
             }
         }
-        
+
         private VisualElement MakeFunctionalityItem()
         {
             var toggle = new CheckboxToggle();
-            var listViewItem = new ListViewItem(toggle);
-            return listViewItem;
+            toggle.RegisterValueChangedCallback(OnFunctionalityChanged);
+            return new ListViewItem(toggle);
         }
 
         private void BindFunctionalityItem(VisualElement item, int index)
@@ -63,15 +63,19 @@ namespace Netherlands3D.UI.Panels
             if (item is not ListViewItem listViewItem) return;
             if (listViewItem.Q<CheckboxToggle>() is not CheckboxToggle toggle) return;
 
-            Functionality functionality = functionalitiesListView.itemsSource[index] as Functionality;
+            var functionality = (Functionality)functionalitiesListView.itemsSource[index];
+            toggle.userData = functionality;
             toggle.LabelText = functionality.Title;
             toggle.SetValueWithoutNotify(functionality.IsEnabled);
+        }
 
-            toggle.RegisterValueChangedCallback(evt =>
-            { 
-                functionality.IsEnabled = evt.newValue;
-                App.Debug.DisplayMessage("Functie voorkeuren succesvol aangepast", IconImage.CHECKMARK);
-            });
+        private void OnFunctionalityChanged(ChangeEvent<bool> evt)
+        {
+            if (evt.currentTarget is not CheckboxToggle toggle || toggle.userData is not Functionality functionality)
+                return;
+
+            functionality.IsEnabled = evt.newValue;
+            App.Debug.DisplayMessage("Functie voorkeuren succesvol aangepast", IconImage.CHECKMARK);
         }
 
         private void OnQualitySettingsChanged(ChangeEvent<int> evt)

--- a/Assets/_Application/Projects/ProjectData.cs
+++ b/Assets/_Application/Projects/ProjectData.cs
@@ -50,6 +50,9 @@ namespace Netherlands3D.Twin.Projects
         public bool UseCurrentTime = false;
         [SerializeField, JsonProperty] public List<FunctionalityData> functionalities = new();
         [SerializeField, JsonProperty] private RootLayer rootLayer;
+        [SerializeField, JsonProperty] public bool PresentationLeftPinned = true;
+        [SerializeField, JsonProperty] public bool PresentationToolboxPinned = true;
+        [SerializeField, JsonProperty] public bool PresentationNavigationPinned = true;
         [JsonIgnore] public PrefabLibrary PrefabLibrary; //for some reason this cannot be a field backed property because it will still try to serialize it even with the correct tags applied
 
         [JsonIgnore]
@@ -83,6 +86,7 @@ namespace Netherlands3D.Twin.Projects
             current = initialProjectTemplate;
             current.RootLayer = new RootLayer("RootLayer");
             current.functionalities = new();
+            current.ResetPresentationPins();
         }
 
         public void LoadVisualizations()
@@ -95,7 +99,14 @@ namespace Netherlands3D.Twin.Projects
                 App.Layers.VisualizeData(layer);
             }
         }
-        
+
+        public void ResetPresentationPins()
+        {
+            PresentationLeftPinned = true;
+            PresentationToolboxPinned = true;
+            PresentationNavigationPinned = true;
+        }
+
         /// <summary>
         /// Recursively collect all assets from each of the property data elements of every layer for loading and
         /// saving purposes. 

--- a/Assets/_Application/Projects/ProjectDataHandler.cs
+++ b/Assets/_Application/Projects/ProjectDataHandler.cs
@@ -220,6 +220,8 @@ namespace Netherlands3D.Twin.Projects
         {
             try
             {
+                ProjectData.Current.ResetPresentationPins();
+                ProjectData.Current.functionalities.RemoveAll(functionality => functionality.Id == "presentation-mode");
                 JsonConvert.PopulateObject(json, ProjectData.Current, serializerSettings);
             }
             catch(Exception e)

--- a/Assets/_BuildingBlocks/Configuration/ScriptableObjects/Configuration.asset
+++ b/Assets/_BuildingBlocks/Configuration/ScriptableObjects/Configuration.asset
@@ -23,6 +23,7 @@ MonoBehaviour:
   Functionalities:
   - {fileID: 11400000, guid: 77c433a944001411a9376d15fb427d17, type: 2}
   - {fileID: 11400000, guid: 73566e5fce73b5440b33ed107ed5be94, type: 2}
+  - {fileID: 11400000, guid: 701372591ba40ef4e9b09a5b5ad8f7d5, type: 2}
   corsProxyUrl: 
   OnAllowUserSettingsChanged:
     m_PersistentCalls:

--- a/Assets/_BuildingBlocks/Configuration/Scripts/Configuration.cs
+++ b/Assets/_BuildingBlocks/Configuration/Scripts/Configuration.cs
@@ -288,6 +288,11 @@ namespace Netherlands3D.Twin.Configuration
 
         private void LoadFunctionalitiesFromProject(ProjectData changedData)
         {
+            var presentationFunctionality = Functionalities.FirstOrDefault(functionality => functionality.Id == "presentation-mode");
+
+            if (presentationFunctionality != null && !changedData.functionalities.Any(functionality => functionality.Id == "presentation-mode"))
+                presentationFunctionality.IsEnabled = false;
+
             foreach (var savedData in changedData.functionalities)
             {
                 var savedId = savedData.Id;

--- a/Assets/_Functionalities/PresentationMode/Functionality_PresentationMode.asset
+++ b/Assets/_Functionalities/PresentationMode/Functionality_PresentationMode.asset
@@ -1,0 +1,28 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 714e859e1c414d479484fe937804ce24, type: 3}
+  m_Name: Functionality_PresentationMode
+  m_EditorClassIdentifier: eu.netherlands3d.twin.functionalities::Netherlands3D.Twin.Functionalities.Functionality
+  data:
+    Id: presentation-mode
+    IsEnabled: 0
+  Title: Presentatiemodus
+  Caption: 
+  Header: 
+  Description: UI-secties vastzetten en verbergen voor presentaties.
+  configuration: {fileID: 0}
+  OnEnable:
+    m_PersistentCalls:
+      m_Calls: []
+  OnDisable:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/_Functionalities/PresentationMode/Functionality_PresentationMode.asset.meta
+++ b/Assets/_Functionalities/PresentationMode/Functionality_PresentationMode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 701372591ba40ef4e9b09a5b5ad8f7d5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Functionalities/PresentationMode/Scripts/UIHider.cs
+++ b/Assets/_Functionalities/PresentationMode/Scripts/UIHider.cs
@@ -3,7 +3,6 @@ using Netherlands3D.Services;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
-using Netherlands3D.UI_Toolkit.Scripts;
 
 namespace Netherlands3D.Twin.PresentationModus.UIHider
 {
@@ -13,8 +12,18 @@ namespace Netherlands3D.Twin.PresentationModus.UIHider
     {
         [SerializeField] private InputActionReference hideButton;
 
-        private List<IPanelHider> panelHiders = new List<IPanelHider>();
+        private readonly List<IPanelHider> panelHiders = new();
         private bool hideUI;
+        private const float RevealDelay = 0.15f;
+        private const float HideDelay = 0.30f;
+        private const float MinimumShowTime = 0.40f;
+
+        private readonly Dictionary<IPanelHider, HoverTiming> hoverTimings = new();
+
+        public const string FunctionalityId = "presentation-mode";
+
+        public bool IsPresenting { get; private set; }
+        public event System.Action PresentationChanged;
 
         private void Start()
         {
@@ -36,33 +45,106 @@ namespace Netherlands3D.Twin.PresentationModus.UIHider
 
         public void Unregister(IPanelHider panelHider)
         {
-            if (panelHiders.Contains(panelHider))
-                panelHiders.Remove(panelHider);
+            panelHiders.Remove(panelHider);
+            hoverTimings.Remove(panelHider);
         }
 
         private void Update()
         {
-            Vector2 mousePosition = Pointer.current.position.ReadValue();
+            if (!hideUI || IsPresenting || Pointer.current == null)
+                return;
 
-            if (!hideUI) return;
+            var mousePosition = Pointer.current.position.ReadValue();
+            var now = Time.unscaledTime;
 
-            panelHiders.ForEach(panel =>
+            for (var i = 0; i < panelHiders.Count; i++)
             {
-                bool isMouseOver = panel.IsMouseOver(mousePosition);
+                var panel = panelHiders[i];
+                var timing = hoverTimings[panel];
 
-                if (isMouseOver && panel.IsHidden)
-                    panel.Show();
-                else if (!isMouseOver && !panel.Pinned && !panel.IsHidden)
-                    panel.Hide();
-            });
+                if (timing.IsHidden != panel.IsHidden)
+                {
+                    timing.IsHidden = panel.IsHidden;
+                    timing.StartedAt = -1f;
+                }
+
+                if (panel.Pinned)
+                {
+                    timing.StartedAt = -1f;
+                    hoverTimings[panel] = timing;
+                    continue;
+                }
+
+                var isMouseOver = panel.IsMouseOver(mousePosition);
+                var shouldChangeVisibility = panel.IsHidden ? isMouseOver : !isMouseOver;
+
+                if (!shouldChangeVisibility)
+                {
+                    timing.StartedAt = -1f;
+                }
+                else if (timing.StartedAt < 0f)
+                {
+                    timing.StartedAt = now;
+                }
+                else
+                {
+                    var delay = panel.IsHidden ? RevealDelay : HideDelay;
+
+                    if (now - timing.StartedAt >= delay && (panel.IsHidden || now >= timing.EarliestHideAt))
+                    {
+                        if (panel.IsHidden)
+                        {
+                            panel.Show();
+                            timing.EarliestHideAt = now + MinimumShowTime;
+                        }
+                        else
+                        {
+                            panel.Hide();
+                        }
+
+                        timing.IsHidden = panel.IsHidden;
+                        timing.StartedAt = -1f;
+                    }
+                }
+
+                hoverTimings[panel] = timing;
+            }
         }
 
         public void ToggleUIHider()
         {
-            hideUI = !hideUI;
+            SetPresenting(!IsPresenting);
+        }
 
-            panelHiders.ForEach(panel => SetPanelHide(panel));
-            App.Debug.DisplayMessage("Druk op H om de presentatiemodus te verlaten.", IconImage.PRESENTATION_CHART);
+        public void SetPresenting(bool presenting)
+        {
+            presenting &= hideUI;
+
+            if (IsPresenting == presenting)
+                return;
+
+            IsPresenting = presenting;
+            RefreshPanels();
+            PresentationChanged?.Invoke();
+        }
+
+        public void SetPresentationEnabled(bool enabled)
+        {
+            hideUI = enabled;
+
+            if (!enabled && IsPresenting)
+            {
+                SetPresenting(false);
+                return;
+            }
+
+            RefreshPanels();
+        }
+
+        public void RefreshPanels()
+        {
+            foreach (var panel in panelHiders)
+                SetPanelHide(panel);
         }
 
         private void SetPanelHide(IPanelHider panel)
@@ -71,8 +153,14 @@ namespace Netherlands3D.Twin.PresentationModus.UIHider
 
             if (hideUI && !panel.Pinned)
                 panel.Hide();
-            else if (!hideUI)
+            else
                 panel.Show();
+
+            hoverTimings[panel] = new HoverTiming
+            {
+                IsHidden = panel.IsHidden,
+                StartedAt = -1f
+            };
         }
 
         private void OnHideUIPressed(InputAction.CallbackContext context)
@@ -82,6 +170,13 @@ namespace Netherlands3D.Twin.PresentationModus.UIHider
                 return;
 
             ToggleUIHider();
+        }
+
+        private struct HoverTiming
+        {
+            public bool IsHidden;
+            public float StartedAt;
+            public float EarliestHideAt;
         }
     }
 }


### PR DESCRIPTION
Enable presentation mode in Settings to show the pins and presentation button. Unpinned sections slide away and temporarily return when hovering near the screen edge. Pin preferences and the setting are saved with the project.

Use the presentation button or H to hide the pins and disable hover, keeping a fixed view based on the selected pins. Toggle again to continue configuring.